### PR TITLE
feat: add auto-lock feature

### DIFF
--- a/app/src/main/java/com/aritradas/uncrack/MainActivity.kt
+++ b/app/src/main/java/com/aritradas/uncrack/MainActivity.kt
@@ -52,6 +52,13 @@ class MainActivity : FragmentActivity(), InstallStateUpdatedListener {
 
     private lateinit var appUpdateManager: AppUpdateManager
     private var appInBackground = false
+    private var lastBackgroundTime = 0L
+
+    companion object {
+        const val EXTRA_NAVIGATE_TO = "navigate_to"
+        const val EXTRA_PREVIOUS_ROUTE = "previous_route"
+        const val EXTRA_CURRENT_ROUTE = "current_route"
+    }
 
     private val activityResultLauncher = registerForActivityResult(
         ActivityResultContracts.StartIntentSenderForResult()
@@ -241,7 +248,7 @@ class MainActivity : FragmentActivity(), InstallStateUpdatedListener {
         // Check if auto-lock needs to be triggered
         if (appInBackground) {
             appInBackground = false
-            handleAutoLock()
+            checkAndHandleAutoLock()
         }
 
         // For FLEXIBLE updates, check if an update has been downloaded
@@ -273,6 +280,7 @@ class MainActivity : FragmentActivity(), InstallStateUpdatedListener {
     override fun onPause() {
         super.onPause()
         appInBackground = true
+        lastBackgroundTime = System.currentTimeMillis()
     }
 
     override fun onDestroy() {
@@ -281,12 +289,64 @@ class MainActivity : FragmentActivity(), InstallStateUpdatedListener {
         appUpdateManager.unregisterListener(this)
     }
 
+    /**
+     * Check if enough time has elapsed for auto-lock and trigger if needed
+     */
+    private fun checkAndHandleAutoLock() {
+        // Using the ViewModel methods to avoid StateFlow access issues
+        val shouldLock = settingsViewModel.shouldLockApp()
+
+        if (shouldLock) {
+            val currentTime = System.currentTimeMillis()
+            val timeInBackground = currentTime - lastBackgroundTime
+            val configuredTimeout = settingsViewModel.getAutoLockTimeoutMs()
+
+            // Log for debugging
+            Timber.d("Time in background: $timeInBackground ms, Configured timeout: $configuredTimeout ms")
+
+            if (timeInBackground >= configuredTimeout) {
+                // Get the current route - this is what we want to return to after authentication
+                val currentRoute =
+                    intent.getStringExtra(EXTRA_CURRENT_ROUTE) ?: Screen.VaultScreen.name
+                val useBiometric = settingsViewModel.shouldUseBiometric()
+
+                Timber.d("Auto-locking after timeout. Current route: $currentRoute")
+
+                if (useBiometric) {
+                    // Show biometric prompt
+                    viewModel.showBiometricPrompt(this)
+                } else {
+                    // Navigate to master key confirmation screen
+                    val intent = Intent(this, MainActivity::class.java)
+                    intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    intent.putExtra(EXTRA_NAVIGATE_TO, Screen.ConfirmMasterKeyScreen.name)
+                    intent.putExtra(EXTRA_PREVIOUS_ROUTE, currentRoute)
+
+                    // Log for verification
+                    Timber.d("Starting ConfirmMasterKey with previous_route: $currentRoute")
+
+                    startActivity(intent)
+                    finish()
+                }
+            } else {
+                Timber.d("Not enough time elapsed for auto-lock")
+            }
+        }
+    }
+
+    @Deprecated("Use checkAndHandleAutoLock instead")
     private fun handleAutoLock() {
         // Using the ViewModel methods to avoid StateFlow access issues
         val shouldLock = settingsViewModel.shouldLockApp()
         val useBiometric = settingsViewModel.shouldUseBiometric()
 
         if (shouldLock) {
+            // Get the current route - this is what we want to return to after authentication
+            val currentRoute = intent.getStringExtra(EXTRA_CURRENT_ROUTE) ?: Screen.VaultScreen.name
+
+            // Log for debugging
+            Timber.d("Auto-locking. Current route: $currentRoute")
+            
             if (useBiometric) {
                 // Show biometric prompt
                 viewModel.showBiometricPrompt(this)
@@ -294,7 +354,12 @@ class MainActivity : FragmentActivity(), InstallStateUpdatedListener {
                 // Navigate to master key confirmation screen
                 val intent = Intent(this, MainActivity::class.java)
                 intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-                intent.putExtra("navigate_to", Screen.ConfirmMasterKeyScreen.name)
+                intent.putExtra(EXTRA_NAVIGATE_TO, Screen.ConfirmMasterKeyScreen.name)
+                intent.putExtra(EXTRA_PREVIOUS_ROUTE, currentRoute)
+
+                // Log for verification
+                Timber.d("Starting ConfirmMasterKey with previous_route: $currentRoute")
+                
                 startActivity(intent)
                 finish()
             }

--- a/app/src/main/java/com/aritradas/uncrack/data/datastore/DataStoreUtil.kt
+++ b/app/src/main/java/com/aritradas/uncrack/data/datastore/DataStoreUtil.kt
@@ -16,5 +16,6 @@ class DataStoreUtil @Inject constructor(context: Context) {
         val IS_DARK_MODE_KEY = booleanPreferencesKey("dark_mode")
         val IS_SS_BLOCK_KEY = booleanPreferencesKey("ss_block")
         val IS_BIOMETRIC_AUTH_SET_KEY = booleanPreferencesKey("biometric_auth")
+        val IS_AUTO_LOCK_ENABLED_KEY = booleanPreferencesKey("auto_lock_enabled")
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/data/datastore/DataStoreUtil.kt
+++ b/app/src/main/java/com/aritradas/uncrack/data/datastore/DataStoreUtil.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import javax.inject.Inject
 
@@ -17,5 +18,6 @@ class DataStoreUtil @Inject constructor(context: Context) {
         val IS_SS_BLOCK_KEY = booleanPreferencesKey("ss_block")
         val IS_BIOMETRIC_AUTH_SET_KEY = booleanPreferencesKey("biometric_auth")
         val IS_AUTO_LOCK_ENABLED_KEY = booleanPreferencesKey("auto_lock_enabled")
+        val AUTO_LOCK_TIMEOUT_KEY = longPreferencesKey("auto_lock_timeout")
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/intro/SplashScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/intro/SplashScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -25,7 +26,6 @@ import com.aritradas.uncrack.R
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.google.firebase.auth.FirebaseAuth
-
 
 @Composable
 fun SplashScreen(
@@ -44,16 +44,20 @@ fun SplashScreen(
         label = ""
     )
     val currentUser = FirebaseAuth.getInstance().currentUser
+    val context = LocalContext.current
+    val activity = context as? android.app.Activity
+    val navigateTo = activity?.intent?.getStringExtra("navigate_to")
 
     LaunchedEffect(Unit) {
         animation = true
 
         if (currentUser == null) {
             navController.navigate(Screen.OnboardingScreen.name)
+        } else if (navigateTo != null) {
+            navController.navigate(navigateTo)
         } else {
             navController.navigate(Screen.ConfirmMasterKeyScreen.name)
         }
-
     }
 
     Surface {

--- a/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
@@ -65,6 +65,7 @@ fun SettingsScreen(
     val onLogOutComplete by settingsViewModel.onLogOutComplete.observeAsState(false)
     val onDeleteAccountComplete by settingsViewModel.onDeleteAccountComplete.observeAsState(false)
     val biometricAuthState by settingsViewModel.biometricAuthState.collectAsState()
+    val autoLockEnabled by settingsViewModel.autoLockEnabled.collectAsState()
     var openThemeDialog by remember { mutableStateOf(false) }
     var openLogoutDialog by remember { mutableStateOf(false) }
     var openDeleteAccountDialog by remember { mutableStateOf(false) }
@@ -263,6 +264,20 @@ fun SettingsScreen(
                     isChecked = biometricAuthState,
                     onChecked = {
                         settingsViewModel.showBiometricPrompt(context as MainActivity)
+                    }
+                )
+
+                HorizontalDivider(
+                    thickness = 2.dp,
+                    color = SurfaceLight
+                )
+
+                UCSwitchCard(
+                    itemName = stringResource(R.string.auto_lock),
+                    itemSubText = stringResource(R.string.automatically_lock_app_when_in_background),
+                    isChecked = autoLockEnabled,
+                    onChecked = {
+                        settingsViewModel.setAutoLockEnabled(it)
                     }
                 )
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.aritradas.uncrack.MainActivity
 import com.aritradas.uncrack.R
+import com.aritradas.uncrack.components.AutoLockTimeoutDialog
 import com.aritradas.uncrack.components.SettingsItemGroup
 import com.aritradas.uncrack.components.ThemeDialog
 import com.aritradas.uncrack.components.UCSettingsCard
@@ -66,9 +67,11 @@ fun SettingsScreen(
     val onDeleteAccountComplete by settingsViewModel.onDeleteAccountComplete.observeAsState(false)
     val biometricAuthState by settingsViewModel.biometricAuthState.collectAsState()
     val autoLockEnabled by settingsViewModel.autoLockEnabled.collectAsState()
+    val autoLockTimeout by settingsViewModel.autoLockTimeout.collectAsState()
     var openThemeDialog by remember { mutableStateOf(false) }
     var openLogoutDialog by remember { mutableStateOf(false) }
     var openDeleteAccountDialog by remember { mutableStateOf(false) }
+    var openAutoLockTimeoutDialog by remember { mutableStateOf(false) }
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
     if (onLogOutComplete || onDeleteAccountComplete) {
@@ -78,6 +81,17 @@ fun SettingsScreen(
     when {
         openThemeDialog -> {
             ThemeDialog(onDismissRequest = { openThemeDialog = false })
+        }
+
+        openAutoLockTimeoutDialog -> {
+            AutoLockTimeoutDialog(
+                timeoutOptions = settingsViewModel.autoLockTimeoutLabels,
+                selectedIndex = settingsViewModel.getSelectedTimeoutIndex(),
+                onTimeoutSelected = { index ->
+                    settingsViewModel.setAutoLockTimeout(settingsViewModel.autoLockTimeoutOptions[index])
+                },
+                onDismissRequest = { openAutoLockTimeoutDialog = false }
+            )
         }
 
         openLogoutDialog -> {
@@ -285,6 +299,22 @@ fun SettingsScreen(
                     thickness = 2.dp,
                     color = SurfaceLight
                 )
+
+                UCSettingsCard(
+                    itemName = stringResource(R.string.auto_lock_timeout),
+                    itemSubText = stringResource(R.string.auto_lock_timeout_description_new).format(
+                        settingsViewModel.getTimeoutLabelForValue(autoLockTimeout)
+                    ),
+                    onClick = {
+                        openAutoLockTimeoutDialog = true
+                    }
+                )
+
+                HorizontalDivider(
+                    thickness = 2.dp,
+                    color = SurfaceLight
+                )
+
 
                 UCSwitchCard(
                     itemName = stringResource(R.string.allow_screenshots),

--- a/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsViewModel.kt
@@ -44,6 +44,29 @@ class SettingsViewModel @Inject constructor(
     private val _autoLockEnabled = MutableStateFlow(false)
     val autoLockEnabled: StateFlow<Boolean> = _autoLockEnabled
 
+    // Available timeout options in milliseconds
+    val autoLockTimeoutOptions = listOf(
+        5000L,       // 5 seconds
+        30000L,      // 30 seconds
+        60000L,      // 1 minute
+        180000L,     // 3 minutes
+        300000L,     // 5 minutes
+        900000L      // 15 minutes
+    )
+
+    // Human-readable timeout labels
+    val autoLockTimeoutLabels = listOf(
+        "5 seconds",
+        "30 seconds",
+        "1 minute",
+        "3 minutes",
+        "5 minutes",
+        "15 minutes"
+    )
+
+    private val _autoLockTimeout = MutableStateFlow(60000L) // Default: 1 minute
+    val autoLockTimeout: StateFlow<Long> = _autoLockTimeout
+
     init {
         viewModelScope.launch(Dispatchers.IO) {
             dataStore.data.map { preferences ->
@@ -58,6 +81,14 @@ class SettingsViewModel @Inject constructor(
                 preferences[DataStoreUtil.IS_AUTO_LOCK_ENABLED_KEY] ?: false
             }.collect {
                 _autoLockEnabled.value = it
+            }
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            dataStore.data.map { preferences ->
+                preferences[DataStoreUtil.AUTO_LOCK_TIMEOUT_KEY] ?: 60000L // Default: 1 minute
+            }.collect {
+                _autoLockTimeout.value = it
             }
         }
     }
@@ -96,12 +127,35 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun setAutoLockTimeout(timeoutMs: Long) {
+        viewModelScope.launch {
+            dataStore.edit { preferences ->
+                preferences[DataStoreUtil.AUTO_LOCK_TIMEOUT_KEY] = timeoutMs
+            }
+        }
+    }
+
+    fun getTimeoutLabelForValue(timeoutMs: Long): String {
+        val index = autoLockTimeoutOptions.indexOf(timeoutMs)
+        return if (index >= 0) autoLockTimeoutLabels[index] else "1 minute"
+    }
+
+    fun getSelectedTimeoutIndex(): Int {
+        val timeout = _autoLockTimeout.value
+        return autoLockTimeoutOptions.indexOf(timeout).takeIf { it >= 0 }
+            ?: 2 // Default to 1 minute (index 2)
+    }
+    
     fun shouldLockApp(): Boolean {
         return _autoLockEnabled.value
     }
 
     fun shouldUseBiometric(): Boolean {
         return _biometricAuthState.value
+    }
+
+    fun getAutoLockTimeoutMs(): Long {
+        return _autoLockTimeout.value
     }
 
     fun logout() = runIO {

--- a/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsViewModel.kt
@@ -41,6 +41,8 @@ class SettingsViewModel @Inject constructor(
     private val dataStore = dataStoreUtil.dataStore
     private val _biometricAuthState = MutableStateFlow(false)
     val biometricAuthState: StateFlow<Boolean> = _biometricAuthState
+    private val _autoLockEnabled = MutableStateFlow(false)
+    val autoLockEnabled: StateFlow<Boolean> = _autoLockEnabled
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -48,6 +50,14 @@ class SettingsViewModel @Inject constructor(
                 preferences[DataStoreUtil.IS_BIOMETRIC_AUTH_SET_KEY] ?: false
             }.collect {
                 _biometricAuthState.value = it
+            }
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            dataStore.data.map { preferences ->
+                preferences[DataStoreUtil.IS_AUTO_LOCK_ENABLED_KEY] ?: false
+            }.collect {
+                _autoLockEnabled.value = it
             }
         }
     }
@@ -76,6 +86,22 @@ class SettingsViewModel @Inject constructor(
 
     fun setScreenshotEnabled(enabled: Boolean) {
         _isScreenshotEnabled.value = enabled
+    }
+
+    fun setAutoLockEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            dataStore.edit { preferences ->
+                preferences[DataStoreUtil.IS_AUTO_LOCK_ENABLED_KEY] = enabled
+            }
+        }
+    }
+
+    fun shouldLockApp(): Boolean {
+        return _autoLockEnabled.value
+    }
+
+    fun shouldUseBiometric(): Boolean {
+        return _biometricAuthState.value
     }
 
     fun logout() = runIO {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,8 @@
     <string name="allow_screenshots_not_recommended">Allow screenshots (not recommended)</string>
     <string name="auto_lock">Auto-lock</string>
     <string name="automatically_lock_app_when_in_background">Automatically lock app when in background</string>
+    <string name="auto_lock_timeout">Auto-lock time</string>
+    <string name="auto_lock_timeout_description_new">Lock the app after %s of inactivity</string>
     <string name="like_uncrack_share_with_friends">Like UnCrack? Share with friends!</string>
     <string name="rate_uncrack_on_the_play_store">Rate UnCrack on the Play Store</string>
     <string-array name="accounts">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,8 @@
     <string name="change_the_master_password_you_use_to_access_uncrack">Change the Master Password you use to access UnCrack</string>
     <string name="use_biometric_to_unlock_the_app">Use biometric to unlock the app</string>
     <string name="allow_screenshots_not_recommended">Allow screenshots (not recommended)</string>
+    <string name="auto_lock">Auto-lock</string>
+    <string name="automatically_lock_app_when_in_background">Automatically lock app when in background</string>
     <string name="like_uncrack_share_with_friends">Like UnCrack? Share with friends!</string>
     <string name="rate_uncrack_on_the_play_store">Rate UnCrack on the Play Store</string>
     <string-array name="accounts">


### PR DESCRIPTION
Issue #281 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an auto-lock option that automatically locks the app when it returns from the background after a configurable timeout.
  - Added a toggle and timeout selection in the security settings to enable, disable, and configure the auto-lock feature.
  - Enhanced navigation logic to support direct access to the master key confirmation screen based on app state and intent extras.

- **User Interface**
  - Added new switch and descriptive text for the auto-lock feature in the settings screen.
  - Added dialog for selecting auto-lock timeout durations.
  - Updated strings to support the new auto-lock feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->