### PR TITLE
Add GeneratorScreen Feature and Refactor Password Generator UI

### DIFF
--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -53,6 +53,7 @@ import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenera
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGeneratorViewModel
 import com.aritradas.uncrack.presentation.tools.passwordHealth.PassHealthViewModel
 import com.aritradas.uncrack.presentation.tools.passwordHealth.PasswordHealthScreen
+import com.aritradas.uncrack.presentation.tools.usernameGenerator.UsernameGeneratorViewModel
 import com.aritradas.uncrack.presentation.vault.AccountSelectionScreen
 import com.aritradas.uncrack.presentation.vault.AddPasswordScreen
 import com.aritradas.uncrack.presentation.vault.EditPasswordScreen
@@ -84,6 +85,7 @@ fun Navigation(
     modifier: Modifier = Modifier,
     authViewModel: AuthViewModel = hiltViewModel(),
     masterKeyViewModel: KeyViewModel = hiltViewModel(),
+    usernameGeneratorViewModel: UsernameGeneratorViewModel = hiltViewModel(),
     passwordGeneratorViewModel: PasswordGeneratorViewModel = hiltViewModel(),
     userViewModel: UserViewModel = hiltViewModel(),
     themeViewModel: ThemeViewModel = hiltViewModel(),
@@ -290,7 +292,8 @@ fun Navigation(
                 route = Screen.GeneratorScreen.name) {
                 GeneratorScreen(
                     navController = navController,
-                    passwordGeneratorViewModel = passwordGeneratorViewModel
+                    passwordGeneratorViewModel = passwordGeneratorViewModel,
+                    usernameGeneratorViewModel = usernameGeneratorViewModel
                 )
             }
 

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -48,6 +48,7 @@ import com.aritradas.uncrack.presentation.profile.ProfileScreen
 import com.aritradas.uncrack.presentation.settings.SettingsScreen
 import com.aritradas.uncrack.presentation.settings.SettingsViewModel
 import com.aritradas.uncrack.presentation.tools.ToolsScreen
+import com.aritradas.uncrack.presentation.tools.generator.GeneratorScreen
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenerator
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGeneratorViewModel
 import com.aritradas.uncrack.presentation.tools.passwordHealth.PassHealthViewModel
@@ -281,6 +282,13 @@ fun Navigation(
                 UpdateMasterKey(
                     navController,
                     masterKeyViewModel
+                )
+            }
+
+            composable(route = Screen.GeneratorScreen.name) {
+                GeneratorScreen(
+                    navController,
+                    passwordGeneratorViewModel
                 )
             }
 

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -109,6 +109,7 @@ fun Navigation(
         "${Screen.EditPasswordScreen.name}/{accountID}",
         Screen.SettingsScreen.name,
         Screen.UpdateMasterKeyScreen.name,
+        Screen.GeneratorScreen.name,
         Screen.PasswordGeneratorScreen.name,
         Screen.CategoryScreen.name,
         "${Screen.ViewPasswordScreen.name}/{id}",
@@ -286,16 +287,10 @@ fun Navigation(
             }
 
             composable(
-                route = "${Screen.GeneratorScreen.name}?tab={tab}",
-                arguments = listOf(
-                    navArgument("tab") { defaultValue = "password" }
-                )
-            ) { backStackEntry ->
-                val initialTab = backStackEntry.arguments?.getString("tab") ?: "password"
+                route = Screen.GeneratorScreen.name) {
                 GeneratorScreen(
                     navController = navController,
-                    passwordGeneratorViewModel = passwordGeneratorViewModel,
-                    initialTab = initialTab
+                    passwordGeneratorViewModel = passwordGeneratorViewModel
                 )
             }
 

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -285,10 +285,17 @@ fun Navigation(
                 )
             }
 
-            composable(route = Screen.GeneratorScreen.name) {
+            composable(
+                route = "${Screen.GeneratorScreen.name}?tab={tab}",
+                arguments = listOf(
+                    navArgument("tab") { defaultValue = "password" }
+                )
+            ) { backStackEntry ->
+                val initialTab = backStackEntry.arguments?.getString("tab") ?: "password"
                 GeneratorScreen(
-                    navController,
-                    passwordGeneratorViewModel
+                    navController = navController,
+                    passwordGeneratorViewModel = passwordGeneratorViewModel,
+                    initialTab = initialTab
                 )
             }
 

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -49,7 +49,6 @@ import com.aritradas.uncrack.presentation.settings.SettingsScreen
 import com.aritradas.uncrack.presentation.settings.SettingsViewModel
 import com.aritradas.uncrack.presentation.tools.ToolsScreen
 import com.aritradas.uncrack.presentation.tools.generator.GeneratorScreen
-import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenerator
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGeneratorViewModel
 import com.aritradas.uncrack.presentation.tools.passwordHealth.PassHealthViewModel
 import com.aritradas.uncrack.presentation.tools.passwordHealth.PasswordHealthScreen
@@ -294,13 +293,6 @@ fun Navigation(
                     navController = navController,
                     passwordGeneratorViewModel = passwordGeneratorViewModel,
                     usernameGeneratorViewModel = usernameGeneratorViewModel
-                )
-            }
-
-            composable(route = Screen.PasswordGeneratorScreen.name) {
-                PasswordGenerator(
-                    navController,
-                    passwordGeneratorViewModel
                 )
             }
 

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Screen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Screen.kt
@@ -20,6 +20,7 @@ sealed class Screen(val name: String) {
     data object ProfileScreen : Screen("profile_screen")
     data object HelpScreen : Screen("help_screen")
     data object UpdateMasterKeyScreen : Screen("update_master_key_screen")
+    data object GeneratorScreen : Screen("generator_screen")
     data object PasswordGeneratorScreen : Screen("password_generator_screen")
     data object PasswordHealthScreen : Screen("password_health_screen")
     data object CategoryScreen : Screen("category_screen")

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
@@ -60,7 +60,7 @@ fun ToolsScreen(
         ) {
 
             Row(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(10.dp))
                     .clickable {
@@ -98,6 +98,49 @@ fun ToolsScreen(
                         color = Color.Gray,
                         style = normal14
 
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(14.dp))
+
+            Row(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable {
+                        navController.navigate("${Screen.GeneratorScreen.name}?tab=username")
+                    }
+                    .background(SurfaceVariantLight)
+                    .shadow(
+                        elevation = 5.dp,
+                        spotColor = Color(0x0D666666),
+                        ambientColor = Color(0x0D666666)
+                    )
+                    .padding(horizontal = 16.dp, vertical = 17.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    modifier = Modifier.size(30.dp),
+                    painter = painterResource(id = R.drawable.person_icon), // Add a username icon to your resources
+                    contentDescription = null
+                )
+
+                Spacer(modifier = Modifier.width(15.dp))
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+                    horizontalAlignment = Alignment.Start,
+                ) {
+                    Text(
+                        text = "Username Generator",
+                        color = Color.Black,
+                        style = medium18
+                    )
+
+                    Text(
+                        text = "Quickly generate unique usernames",
+                        color = Color.Gray,
+                        style = normal14
                     )
                 }
             }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
@@ -64,7 +64,7 @@ fun ToolsScreen(
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(10.dp))
                     .clickable {
-                        navController.navigate(Screen.PasswordGeneratorScreen.name)
+                        navController.navigate(Screen.GeneratorScreen.name)
                     }
                     .background(SurfaceVariantLight)
                     .shadow(

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
@@ -83,62 +83,19 @@ fun ToolsScreen(
                 )
 
                 Spacer(modifier = Modifier.width(15.dp))
+
                 Column(
                     verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
                     horizontalAlignment = Alignment.Start,
                 ) {
                     Text(
-                        text = stringResource(id = R.string.password_generator),
+                        text = stringResource(id = R.string.generator),
                         color = Color.Black,
                         style = medium18
                     )
 
                     Text(
-                        text = stringResource(R.string.quickly_generate_your_new_secure_passwords),
-                        color = Color.Gray,
-                        style = normal14
-
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(14.dp))
-
-            Row(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(10.dp))
-                    .clickable {
-                        navController.navigate("${Screen.GeneratorScreen.name}?tab=username")
-                    }
-                    .background(SurfaceVariantLight)
-                    .shadow(
-                        elevation = 5.dp,
-                        spotColor = Color(0x0D666666),
-                        ambientColor = Color(0x0D666666)
-                    )
-                    .padding(horizontal = 16.dp, vertical = 17.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Image(
-                    modifier = Modifier.size(30.dp),
-                    painter = painterResource(id = R.drawable.person_icon), // Add a username icon to your resources
-                    contentDescription = null
-                )
-
-                Spacer(modifier = Modifier.width(15.dp))
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
-                    horizontalAlignment = Alignment.Start,
-                ) {
-                    Text(
-                        text = "Username Generator",
-                        color = Color.Black,
-                        style = medium18
-                    )
-
-                    Text(
-                        text = "Quickly generate unique usernames",
+                        text = stringResource(R.string.quickly_generate_your_passwords_and_usernames),
                         color = Color.Gray,
                         style = normal14
                     )

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCTopAppBar
 import com.aritradas.uncrack.presentation.tools.usernameGenerator.UsernameGenerator
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenerator
@@ -43,7 +45,7 @@ fun GeneratorScreen(
         topBar = {
             UCTopAppBar(
                 modifier = Modifier.fillMaxWidth(),
-                title = "Generator",
+                title = stringResource(R.string.generator),
                 colors = TopAppBarDefaults.topAppBarColors(BackgroundLight),
                 onBackPress = { navController.popBackStack() }
             )
@@ -80,13 +82,11 @@ fun GeneratorScreen(
             // Change the content based on the selected tab
             when (selectedTab) {
                 "Password" -> PasswordGenerator(
-                    navController = navController,
                     passwordGeneratorViewModel = passwordGeneratorViewModel,
                     modifier = Modifier.weight(1f)
                 )
 
                 "Username" -> UsernameGenerator(
-                    navController = navController,
                     usernameGeneratorViewModel = usernameGeneratorViewModel,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
@@ -1,0 +1,106 @@
+package com.aritradas.uncrack.presentation.tools.generator
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.aritradas.uncrack.components.UCTopAppBar
+import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenerator
+import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGeneratorViewModel
+import com.aritradas.uncrack.ui.theme.BackgroundLight
+import com.aritradas.uncrack.ui.theme.PrimaryLight
+import com.aritradas.uncrack.ui.theme.SurfaceLight
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GeneratorScreen(
+    navController: NavHostController,
+    passwordGeneratorViewModel: PasswordGeneratorViewModel,
+    modifier: Modifier = Modifier
+) {
+    var selectedTab by remember { mutableStateOf("Password") }
+
+    Scaffold(
+        topBar = {
+            UCTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Generator",
+                colors = TopAppBarDefaults.topAppBarColors(BackgroundLight),
+                onBackPress = { navController.popBackStack() }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Button(
+                    onClick = { selectedTab = "Password" },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (selectedTab == "Password") PrimaryLight else SurfaceLight
+                    )
+                ) {
+                    Text("Password")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = { selectedTab = "Username" },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (selectedTab == "Username") PrimaryLight else SurfaceLight
+                    )
+                ) {
+                    Text("Username")
+                }
+            }
+
+            // Change the content based on the selected tab
+            when (selectedTab) {
+                "Password" -> PasswordGenerator(
+                    navController = navController,
+                    passwordGeneratorViewModel = passwordGeneratorViewModel,
+                    modifier = Modifier.weight(1f)
+                )
+
+                "Username" -> UsernameGeneratorPlaceholder(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+// Delete this placeholder when the UsernameGenerator is implemented
+@Composable
+fun UsernameGeneratorPlaceholder(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Username generator coming soon!")
+    }
+}

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
@@ -1,18 +1,15 @@
 package com.aritradas.uncrack.presentation.tools.generator
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.material3.SegmentedButton
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -28,17 +25,18 @@ import com.aritradas.uncrack.components.UCTopAppBar
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenerator
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGeneratorViewModel
 import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.PrimaryLight
-import com.aritradas.uncrack.ui.theme.SurfaceLight
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GeneratorScreen(
     navController: NavHostController,
     passwordGeneratorViewModel: PasswordGeneratorViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    initialTab: String = "password"
 ) {
-    var selectedTab by remember { mutableStateOf("Password") }
+    var selectedTab by remember { mutableStateOf(
+        if (initialTab.equals("username", true)) "Username" else "Password")
+    }
 
     Scaffold(
         topBar = {
@@ -55,29 +53,27 @@ fun GeneratorScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            Row(
+            SingleChoiceSegmentedButtonRow(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.Center
+                    .padding(18.dp)
             ) {
-                Button(
+                SegmentedButton(
+                    selected = selectedTab == "Password",
                     onClick = { selectedTab = "Password" },
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (selectedTab == "Password") PrimaryLight else SurfaceLight
-                    )
-                ) {
-                    Text("Password")
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
+                    shape = RoundedCornerShape(
+                        topStart = 16.dp, bottomStart = 16.dp, topEnd = 0.dp, bottomEnd = 0.dp
+                    ),
+                    label = { Text("Password") }
+                )
+                SegmentedButton(
+                    selected = selectedTab == "Username",
                     onClick = { selectedTab = "Username" },
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (selectedTab == "Username") PrimaryLight else SurfaceLight
-                    )
-                ) {
-                    Text("Username")
-                }
+                    shape = RoundedCornerShape(
+                        topStart = 0.dp, bottomStart = 0.dp, topEnd = 16.dp, bottomEnd = 16.dp
+                    ),
+                    label = { Text("Username") }
+                )
             }
 
             // Change the content based on the selected tab

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
@@ -1,7 +1,6 @@
 package com.aritradas.uncrack.presentation.tools.generator
 
 import androidx.compose.material3.SegmentedButton
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,13 +16,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.aritradas.uncrack.components.UCTopAppBar
+import com.aritradas.uncrack.presentation.tools.usernameGenerator.UsernameGenerator
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenerator
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGeneratorViewModel
+import com.aritradas.uncrack.presentation.tools.usernameGenerator.UsernameGeneratorViewModel
 import com.aritradas.uncrack.ui.theme.BackgroundLight
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -31,6 +31,7 @@ import com.aritradas.uncrack.ui.theme.BackgroundLight
 fun GeneratorScreen(
     navController: NavHostController,
     passwordGeneratorViewModel: PasswordGeneratorViewModel,
+    usernameGeneratorViewModel: UsernameGeneratorViewModel,
     modifier: Modifier = Modifier,
     initialTab: String = "password"
 ) {
@@ -84,19 +85,12 @@ fun GeneratorScreen(
                     modifier = Modifier.weight(1f)
                 )
 
-                "Username" -> UsernameGeneratorPlaceholder(modifier = Modifier.weight(1f))
+                "Username" -> UsernameGenerator(
+                    navController = navController,
+                    usernameGeneratorViewModel = usernameGeneratorViewModel,
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
-    }
-}
-
-// Delete this placeholder when the UsernameGenerator is implemented
-@Composable
-fun UsernameGeneratorPlaceholder(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text("Username generator coming soon!")
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -103,154 +103,142 @@ fun PasswordGenerator(
         Timber.d("Progress message $progressMessage")
     }
 
-    Scaffold(
-        topBar = {
-            UCTopAppBar(
-                modifier = modifier.fillMaxWidth(),
-                title = "Password Generator",
-                colors = TopAppBarDefaults.topAppBarColors(BackgroundLight),
-                onBackPress = { navController.popBackStack() }
-            )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .background(BackgroundLight)
-                .verticalScroll(scrollState)
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = buildAnnotatedString {
-                    password.forEach {
-                        val textColor = when {
-                            it.isDigit() -> Color.Blue
-                            it.isLetterOrDigit().not() -> Color.Magenta
-                            else -> OnPrimaryContainerLight
-                        }
-                        withStyle(style = SpanStyle(color = textColor)) {
-                            append(it.toString())
-                        }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BackgroundLight)
+            .verticalScroll(scrollState)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = buildAnnotatedString {
+                password.forEach {
+                    val textColor = when {
+                        it.isDigit() -> Color.Blue
+                        it.isLetterOrDigit().not() -> Color.Magenta
+                        else -> OnPrimaryContainerLight
                     }
-                },
-                style = medium30,
-                textAlign = TextAlign.Center,
-                letterSpacing = TextUnit(1F, TextUnitType.Sp)
-            )
-
-            UCButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(R.string.copy),
-                onClick = {
-                    password.let { passwordToCopy ->
-                        clipboardManager.setText(AnnotatedString((passwordToCopy)))
+                    withStyle(style = SpanStyle(color = textColor)) {
+                        append(it.toString())
                     }
-                    Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
-                },
-                leadingIcon = painterResource(id = R.drawable.copy_password)
-            )
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            Row (
-                verticalAlignment = Alignment.CenterVertically
-            ){
-                Text(
-                    text = stringResource(R.string.password_score),
-                    style = medium24.copy(OnPrimaryContainerLight)
-                )
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                Box(contentAlignment = Alignment.Center) {
-
-                    CircularProgressIndicator(
-                        progress = { progressValue },
-                        modifier = Modifier.size(40.dp),
-                        color = when {
-                            passwordStrength <= 3 -> weakPassword
-                            passwordStrength <= 7 -> oldPassword
-                            else -> strongPassword
-                        },
-                        strokeWidth = 5.dp,
-                        trackColor = SurfaceTintLight,
-                        strokeCap = StrokeCap.Round,
-                    )
-
-                    Text(
-                        text = progressMessage,
-                        style = normal12,
-                        color = OnPrimaryContainerLight,
-                    )
                 }
-            }
+            },
+            style = medium30,
+            textAlign = TextAlign.Center,
+            letterSpacing = TextUnit(1F, TextUnitType.Sp)
+        )
 
+        UCButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.copy),
+            onClick = {
+                password.let { passwordToCopy ->
+                    clipboardManager.setText(AnnotatedString((passwordToCopy)))
+                }
+                Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+            },
+            leadingIcon = painterResource(id = R.drawable.copy_password)
+        )
 
-            Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(10.dp))
 
+        Row (
+            verticalAlignment = Alignment.CenterVertically
+        ){
             Text(
-                text = stringResource(R.string.password_generated_length, passwordLength.toInt()),
+                text = stringResource(R.string.password_score),
                 style = medium24.copy(OnPrimaryContainerLight)
             )
 
-            Spacer(modifier = Modifier.height(10.dp))
+            Spacer(modifier = Modifier.width(8.dp))
 
-            Slider(
-                modifier = Modifier.fillMaxWidth(),
-                value = passwordLength,
-                onValueChange = { newPasswordLength ->
-                    passwordGeneratorViewModel.updatePasswordLength(newPasswordLength)
-                },
-                onValueChangeFinished = {
-                    passwordGeneratorViewModel.generatePassword()
-                },
-                steps = sliderSteps,
-                valueRange = sliderStepRange,
-                colors = SliderDefaults.colors(
-                    thumbColor = OnPrimaryContainerLight,
-                    activeTrackColor = PrimaryLight,
-                    inactiveTrackColor = SurfaceLight,
-                    activeTickColor = Color.Transparent,
-                    inactiveTickColor = Color.Transparent
+            Box(contentAlignment = Alignment.Center) {
+
+                CircularProgressIndicator(
+                    progress = { progressValue },
+                    modifier = Modifier.size(40.dp),
+                    color = when {
+                        passwordStrength <= 3 -> weakPassword
+                        passwordStrength <= 7 -> oldPassword
+                        else -> strongPassword
+                    },
+                    strokeWidth = 5.dp,
+                    trackColor = SurfaceTintLight,
+                    strokeCap = StrokeCap.Round,
                 )
+
+                Text(
+                    text = progressMessage,
+                    style = normal12,
+                    color = OnPrimaryContainerLight,
+                )
+            }
+        }
+
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            text = stringResource(R.string.password_generated_length, passwordLength.toInt()),
+            style = medium24.copy(OnPrimaryContainerLight)
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Slider(
+            modifier = Modifier.fillMaxWidth(),
+            value = passwordLength,
+            onValueChange = { newPasswordLength ->
+                passwordGeneratorViewModel.updatePasswordLength(newPasswordLength)
+            },
+            onValueChangeFinished = {
+                passwordGeneratorViewModel.generatePassword()
+            },
+            steps = sliderSteps,
+            valueRange = sliderStepRange,
+            colors = SliderDefaults.colors(
+                thumbColor = OnPrimaryContainerLight,
+                activeTrackColor = PrimaryLight,
+                inactiveTrackColor = SurfaceLight,
+                activeTickColor = Color.Transparent,
+                inactiveTickColor = Color.Transparent
             )
+        )
 
-            Spacer(modifier = Modifier.height(20.dp))
+        Spacer(modifier = Modifier.height(20.dp))
 
-            Text(
-                text = stringResource(R.string.include_following),
-                style = medium24.copy(OnPrimaryContainerLight)
-            )
+        Text(
+            text = stringResource(R.string.include_following),
+            style = medium24.copy(OnPrimaryContainerLight)
+        )
 
-            Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(10.dp))
 
-            SwitchItem(
-                label = stringResource(R.string.numbers),
-                checked = includeNumbers
-            ) {
-                passwordGeneratorViewModel.updateIncludeNumbers(it)
-            }
-            SwitchItem(
-                label = stringResource(R.string.uppercase_letters),
-                checked = includeUppercase
-            ) {
-                passwordGeneratorViewModel.updateIncludeUppercase(it)
-            }
-            SwitchItem(
-                label = stringResource(R.string.lowercase_letters),
-                checked = includeLowercase
-            ) {
-                passwordGeneratorViewModel.updateIncludeLowercase(it)
-            }
-            SwitchItem(
-                label = stringResource(R.string.special_symbols),
-                checked = includeSpecialChars
-            ) {
-                passwordGeneratorViewModel.updateIncludeSpecialChars(it)
-            }
+        SwitchItem(
+            label = stringResource(R.string.numbers),
+            checked = includeNumbers
+        ) {
+            passwordGeneratorViewModel.updateIncludeNumbers(it)
+        }
+        SwitchItem(
+            label = stringResource(R.string.uppercase_letters),
+            checked = includeUppercase
+        ) {
+            passwordGeneratorViewModel.updateIncludeUppercase(it)
+        }
+        SwitchItem(
+            label = stringResource(R.string.lowercase_letters),
+            checked = includeLowercase
+        ) {
+            passwordGeneratorViewModel.updateIncludeLowercase(it)
+        }
+        SwitchItem(
+            label = stringResource(R.string.special_symbols),
+            checked = includeSpecialChars
+        ) {
+            passwordGeneratorViewModel.updateIncludeSpecialChars(it)
         }
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCButton
 import com.aritradas.uncrack.ui.theme.BackgroundLight
@@ -61,7 +60,6 @@ import timber.log.Timber
 
 @Composable
 fun PasswordGenerator(
-    navController: NavHostController,
     passwordGeneratorViewModel: PasswordGeneratorViewModel,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -89,6 +89,10 @@ fun PasswordGenerator(
     val scrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
 
+    LaunchedEffect(Unit) {
+        passwordGeneratorViewModel.generatePassword()
+    }
+
     LaunchedEffect(password) {
         passwordStrength = calculatePasswordStrength(password)
         val mappedScore = (passwordStrength * 100) / 9
@@ -106,33 +110,24 @@ fun PasswordGenerator(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        if (password.isEmpty()) {
-            Text(
-                text = "Please select a password length below",
-                style = normal16.copy(OnPrimaryContainerLight),
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center
-            )
-        } else {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = buildAnnotatedString {
-                    password.forEach {
-                        val textColor = when {
-                            it.isDigit() -> Color.Blue
-                            it.isLetterOrDigit().not() -> Color.Magenta
-                            else -> OnPrimaryContainerLight
-                        }
-                        withStyle(style = SpanStyle(color = textColor)) {
-                            append(it.toString())
-                        }
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = buildAnnotatedString {
+                password.forEach {
+                    val textColor = when {
+                        it.isDigit() -> Color.Blue
+                        it.isLetterOrDigit().not() -> Color.Magenta
+                        else -> OnPrimaryContainerLight
                     }
-                },
-                style = medium30,
-                textAlign = TextAlign.Center,
-                letterSpacing = TextUnit(1F, TextUnitType.Sp)
-            )
-        }
+                    withStyle(style = SpanStyle(color = textColor)) {
+                        append(it.toString())
+                    }
+                }
+            },
+            style = medium30,
+            textAlign = TextAlign.Center,
+            letterSpacing = TextUnit(1F, TextUnitType.Sp)
+        )
 
         UCButton(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -11,11 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Switch
@@ -26,15 +23,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -55,10 +48,8 @@ import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.PrimaryLight
 import com.aritradas.uncrack.ui.theme.SurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.medium24
 import com.aritradas.uncrack.ui.theme.medium30
-import com.aritradas.uncrack.ui.theme.normal12
 import com.aritradas.uncrack.ui.theme.normal16
 import com.aritradas.uncrack.ui.theme.oldPassword
 import com.aritradas.uncrack.ui.theme.strongPassword
@@ -80,14 +71,12 @@ fun PasswordGenerator(
     val passwordLength by passwordGeneratorViewModel.passwordLength.observeAsState(0.0f)
     var passwordStrength by remember { mutableIntStateOf(0) }
     var progressValue by remember { mutableFloatStateOf(0f) }
-    var progressMessage by rememberSaveable { mutableStateOf("") }
     val includeUppercase by passwordGeneratorViewModel.includeUppercase.observeAsState(true)
     val includeLowercase by passwordGeneratorViewModel.includeLowercase.observeAsState(true)
     val includeNumbers by passwordGeneratorViewModel.includeNumbers.observeAsState(true)
     val includeSpecialChars by passwordGeneratorViewModel.includeSpecialChars.observeAsState(true)
 
     val scrollState = rememberScrollState()
-    val scope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
         passwordGeneratorViewModel.generatePassword()
@@ -98,8 +87,6 @@ fun PasswordGenerator(
         val mappedScore = (passwordStrength * 100) / 9
         progressValue = mappedScore.toFloat()
         Timber.d("Progress value $progressValue")
-        progressMessage = passwordStrength.toString()
-        Timber.d("Progress message $progressMessage")
     }
 
     Column(
@@ -129,6 +116,19 @@ fun PasswordGenerator(
             letterSpacing = TextUnit(1F, TextUnitType.Sp)
         )
 
+        val lineColor = when {
+            passwordStrength <= 3 -> weakPassword
+            passwordStrength <= 7 -> oldPassword
+            else -> strongPassword
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(lineColor)
+        )
+
         UCButton(
             modifier = Modifier.fillMaxWidth(),
             text = stringResource(R.string.copy),
@@ -143,47 +143,10 @@ fun PasswordGenerator(
 
         Spacer(modifier = Modifier.height(10.dp))
 
-        Row (
-            verticalAlignment = Alignment.CenterVertically
-        ){
-            Text(
-                text = stringResource(R.string.password_score),
-                style = medium24.copy(OnPrimaryContainerLight)
-            )
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            Box(contentAlignment = Alignment.Center) {
-
-                CircularProgressIndicator(
-                    progress = { progressValue },
-                    modifier = Modifier.size(40.dp),
-                    color = when {
-                        passwordStrength <= 3 -> weakPassword
-                        passwordStrength <= 7 -> oldPassword
-                        else -> strongPassword
-                    },
-                    strokeWidth = 5.dp,
-                    trackColor = SurfaceTintLight,
-                    strokeCap = StrokeCap.Round,
-                )
-
-                Text(
-                    text = progressMessage,
-                    style = normal12,
-                    color = OnPrimaryContainerLight,
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(10.dp))
-
         Text(
             text = stringResource(R.string.password_generated_length, passwordLength.toInt()),
             style = medium24.copy(OnPrimaryContainerLight)
         )
-
-        Spacer(modifier = Modifier.height(10.dp))
 
         Slider(
             modifier = Modifier.fillMaxWidth(),
@@ -205,14 +168,12 @@ fun PasswordGenerator(
             )
         )
 
-        Spacer(modifier = Modifier.height(20.dp))
+        Spacer(modifier = Modifier.height(10.dp))
 
         Text(
             text = stringResource(R.string.include_following),
             style = medium24.copy(OnPrimaryContainerLight)
         )
-
-        Spacer(modifier = Modifier.height(10.dp))
 
         SwitchItem(
             label = stringResource(R.string.numbers),

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -16,13 +16,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -54,7 +51,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCButton
-import com.aritradas.uncrack.components.UCTopAppBar
 import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.PrimaryLight
@@ -72,7 +68,6 @@ import com.aritradas.uncrack.util.Constants.sliderSteps
 import com.aritradas.uncrack.util.UtilsKt.calculatePasswordStrength
 import timber.log.Timber
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PasswordGenerator(
     navController: NavHostController,
@@ -111,24 +106,33 @@ fun PasswordGenerator(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            text = buildAnnotatedString {
-                password.forEach {
-                    val textColor = when {
-                        it.isDigit() -> Color.Blue
-                        it.isLetterOrDigit().not() -> Color.Magenta
-                        else -> OnPrimaryContainerLight
+        if (password.isEmpty()) {
+            Text(
+                text = "Please select a password length below",
+                style = normal16.copy(OnPrimaryContainerLight),
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+        } else {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = buildAnnotatedString {
+                    password.forEach {
+                        val textColor = when {
+                            it.isDigit() -> Color.Blue
+                            it.isLetterOrDigit().not() -> Color.Magenta
+                            else -> OnPrimaryContainerLight
+                        }
+                        withStyle(style = SpanStyle(color = textColor)) {
+                            append(it.toString())
+                        }
                     }
-                    withStyle(style = SpanStyle(color = textColor)) {
-                        append(it.toString())
-                    }
-                }
-            },
-            style = medium30,
-            textAlign = TextAlign.Center,
-            letterSpacing = TextUnit(1F, TextUnitType.Sp)
-        )
+                },
+                style = medium30,
+                textAlign = TextAlign.Center,
+                letterSpacing = TextUnit(1F, TextUnitType.Sp)
+            )
+        }
 
         UCButton(
             modifier = Modifier.fillMaxWidth(),
@@ -176,7 +180,6 @@ fun PasswordGenerator(
                 )
             }
         }
-
 
         Spacer(modifier = Modifier.height(10.dp))
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -1,7 +1,6 @@
 package com.aritradas.uncrack.presentation.tools.passwordGenerator
 
 import android.widget.Toast
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -53,8 +52,6 @@ import com.aritradas.uncrack.ui.theme.medium30
 import com.aritradas.uncrack.ui.theme.normal16
 import com.aritradas.uncrack.util.Constants.sliderStepRange
 import com.aritradas.uncrack.util.Constants.sliderSteps
-import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -113,7 +110,19 @@ fun PasswordGenerator(
                 letterSpacing = TextUnit(1F, TextUnitType.Sp)
             )
 
-            Spacer(modifier = Modifier.height(90.dp))
+            UCButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.copy),
+                onClick = {
+                    password.let { passwordToCopy ->
+                        clipboardManager.setText(AnnotatedString((passwordToCopy)))
+                    }
+                    Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+                },
+                leadingIcon = painterResource(id = R.drawable.copy_password)
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
 
             Text(
                 text = stringResource(R.string.password_generated_length, passwordLength.toInt()),
@@ -127,6 +136,9 @@ fun PasswordGenerator(
                 value = passwordLength,
                 onValueChange = { newPasswordLength ->
                     passwordGeneratorViewModel.updatePasswordLength(newPasswordLength)
+                },
+                onValueChangeFinished = {
+                    passwordGeneratorViewModel.generatePassword()
                 },
                 steps = sliderSteps,
                 valueRange = sliderStepRange,
@@ -172,33 +184,6 @@ fun PasswordGenerator(
             ) {
                 passwordGeneratorViewModel.updateIncludeSpecialChars(it)
             }
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            UCButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(R.string.generate),
-                onClick = {
-                    passwordGeneratorViewModel.generatePassword()
-                    scope.launch {
-                        scrollState.animateScrollTo(value = 0, animationSpec = tween(200))
-                    }
-                    Timber.d("Password ${passwordGeneratorViewModel.generatePassword()}")
-                },
-                leadingIcon = painterResource(id = R.drawable.generate_password)
-            )
-
-            UCButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(R.string.copy),
-                onClick = {
-                    password.let { passwordToCopy ->
-                        clipboardManager.setText(AnnotatedString((passwordToCopy)))
-                    }
-                    Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
-                },
-                leadingIcon = painterResource(id = R.drawable.copy_password)
-            )
         }
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -20,7 +21,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCButton
+import com.aritradas.uncrack.presentation.tools.passwordGenerator.SwitchItem
 import com.aritradas.uncrack.ui.theme.BackgroundLight
+import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
+import com.aritradas.uncrack.ui.theme.medium24
 import com.aritradas.uncrack.ui.theme.medium30
 
 @Composable
@@ -31,6 +35,8 @@ fun UsernameGenerator(
     val context = LocalContext.current
     val clipboardManager: ClipboardManager = LocalClipboardManager.current
     val username = usernameGeneratorViewModel.username.observeAsState("")
+    val useCapitalization by usernameGeneratorViewModel.useCapitalization.observeAsState(true)
+    val includeNumbers by usernameGeneratorViewModel.includeNumbers.observeAsState(true)
 
     LaunchedEffect(Unit) {
         usernameGeneratorViewModel.generateUsername()
@@ -68,5 +74,25 @@ fun UsernameGenerator(
             },
             leadingIcon = painterResource(id = R.drawable.copy_password)
         )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            text = stringResource(R.string.include_following),
+            style = medium24.copy(OnPrimaryContainerLight)
+        )
+
+        SwitchItem(
+            label = stringResource(R.string.numbers),
+            checked = includeNumbers
+        ) {
+            usernameGeneratorViewModel.updateIncludeNumbers(it)
+        }
+        SwitchItem(
+            label = stringResource(R.string.uppercase_letters),
+            checked = useCapitalization
+        ) {
+            usernameGeneratorViewModel.updateUseCapitalization(it)
+        }
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
@@ -3,7 +3,6 @@ package com.aritradas.uncrack.presentation.tools.usernameGenerator
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavHostController
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -26,7 +25,6 @@ import com.aritradas.uncrack.ui.theme.medium30
 
 @Composable
 fun UsernameGenerator(
-    navController: NavHostController,
     usernameGeneratorViewModel: UsernameGeneratorViewModel,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
@@ -1,15 +1,27 @@
 package com.aritradas.uncrack.presentation.tools.usernameGenerator
 
+import android.widget.Toast
+import androidx.compose.foundation.background
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCButton
+import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.medium30
 
 @Composable
@@ -18,29 +30,45 @@ fun UsernameGenerator(
     usernameGeneratorViewModel: UsernameGeneratorViewModel,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+    val clipboardManager: ClipboardManager = LocalClipboardManager.current
     val username = usernameGeneratorViewModel.username.observeAsState("")
 
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+    LaunchedEffect(Unit) {
+        usernameGeneratorViewModel.generateUsername()
+    }
+
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BackgroundLight)
+            .verticalScroll(scrollState)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(24.dp)
-        ) {
-            Text(
-                text = username.value,
-                style = medium30,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
-            )
-            UCButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp),
-                text = "Generate Username",
-                onClick = { usernameGeneratorViewModel.generateUsername() }
-            )
-        }
+        Text(
+            text = username.value,
+            style = medium30,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        UCButton(
+            modifier = Modifier
+                .fillMaxWidth(),
+            text = "Generate Username",
+            onClick = { usernameGeneratorViewModel.generateUsername() }
+        )
+        UCButton(
+            modifier = Modifier
+                .fillMaxWidth(),
+            text = stringResource(R.string.copy),
+            onClick = {
+                clipboardManager.setText(AnnotatedString(username.value))
+                Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+            },
+            leadingIcon = painterResource(id = R.drawable.copy_password)
+        )
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
@@ -1,0 +1,46 @@
+package com.aritradas.uncrack.presentation.tools.usernameGenerator
+
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.aritradas.uncrack.components.UCButton
+import com.aritradas.uncrack.ui.theme.medium30
+
+@Composable
+fun UsernameGenerator(
+    navController: NavHostController,
+    usernameGeneratorViewModel: UsernameGeneratorViewModel,
+    modifier: Modifier = Modifier
+) {
+    val username = usernameGeneratorViewModel.username.observeAsState("")
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            Text(
+                text = username.value,
+                style = medium30,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            UCButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+                text = "Generate Username",
+                onClick = { usernameGeneratorViewModel.generateUsername() }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
@@ -1,0 +1,47 @@
+package com.aritradas.uncrack.presentation.tools.usernameGenerator
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.random.Random
+
+@HiltViewModel
+class UsernameGeneratorViewModel @Inject constructor() : ViewModel() {
+
+    private val adjectives = listOf(
+        "Happy",
+        "Sad",
+        "Brave",
+        "Clever",
+        "Swift",
+        "Calm",
+        "Lively",
+        "Shy",
+        "Witty",
+        "Bold"
+    )
+    private val nouns = listOf(
+        "Ghost",
+        "Trumpet",
+        "Tiger",
+        "Falcon",
+        "Wizard",
+        "Panda",
+        "Rocket",
+        "Shadow",
+        "Lion",
+        "Otter"
+    )
+
+    private val _username = MutableLiveData<String>()
+    val username: LiveData<String> = _username
+
+    fun generateUsername() {
+        val adjective = adjectives.random()
+        val noun = nouns.random()
+        val number = Random.nextInt(100, 1000) // 3-digit number
+        _username.value = "$adjective$noun$number"
+    }
+}

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
@@ -11,26 +11,58 @@ import kotlin.random.Random
 class UsernameGeneratorViewModel @Inject constructor() : ViewModel() {
 
     private val adjectives = listOf(
-        "Happy", "Sad", "Brave", "Clever", "Swift", "Calm", "Lively", "Shy", "Witty", "Bold",
-        "Cheerful", "Gentle", "Fierce", "Nimble", "Quiet", "Energetic", "Mysterious", "Playful",
-        "Serene", "Vibrant", "Graceful", "Mighty", "Sneaky", "Brilliant", "Curious", "Daring",
-        "Elegant", "Faithful", "Jovial", "Keen", "Loyal", "Noble", "Peaceful", "Quick",
-        "Radiant", "Steady", "Trusty", "Unique", "Valiant", "Wise", "Zealous"
+        "happy", "sad", "brave", "clever", "swift", "calm", "lively", "shy", "witty", "bold",
+        "cheerful", "gentle", "fierce", "nimble", "quiet", "energetic", "mysterious", "playful",
+        "serene", "vibrant", "graceful", "mighty", "sneaky", "brilliant", "curious", "daring",
+        "elegant", "faithful", "jovial", "keen", "loyal", "noble", "peaceful", "quick",
+        "radiant", "steady", "trusty", "unique", "valiant", "wise", "zealous"
     )
     private val nouns = listOf(
-        "Ghost", "Trumpet", "Tiger", "Falcon", "Wizard", "Panda", "Rocket", "Shadow", "Lion", "Otter",
-        "Eagle", "Phoenix", "Dragon", "Wolf", "Bear", "Fox", "Hawk", "Jaguar", "Leopard", "Lynx",
-        "Shark", "Whale", "Dolphin", "Penguin", "Sparrow", "Raven", "Owl", "Swan", "Deer", "Horse",
-        "Elephant", "Rhino", "Hippo", "Giraffe", "Zebra", "Kangaroo", "Koala", "Sloth", "Turtle", "Frog"
+        "ghost", "trumpet", "tiger", "falcon", "wizard", "panda", "rocket", "shadow", "lion", "otter",
+        "eagle", "phoenix", "dragon", "wolf", "bear", "fox", "hawk", "jaguar", "leopard", "lynx",
+        "shark", "whale", "dolphin", "penguin", "sparrow", "raven", "owl", "swan", "deer", "horse",
+        "elephant", "rhino", "hippo", "giraffe", "zebra", "kangaroo", "koala", "sloth", "turtle", "frog"
     )
 
     private val _username = MutableLiveData<String>()
     val username: LiveData<String> = _username
 
+    private val _includeNumbers = MutableLiveData(true)
+    val includeNumbers: LiveData<Boolean> = _includeNumbers
+
+    private val _useCapitalization = MutableLiveData(true)
+    val useCapitalization: LiveData<Boolean> = _useCapitalization
+
     fun generateUsername() {
-        val adjective = adjectives.random()
-        val noun = nouns.random()
-        val number = Random.nextInt(100, 1000) // 3-digit number
-        _username.value = "$adjective$noun$number"
+        _username.value = generateUsername(
+            includeNumbers = _includeNumbers.value ?: true,
+            useCapitalization = _useCapitalization.value ?: true,
+        )
+    }
+
+    fun updateIncludeNumbers(include: Boolean) {
+        _includeNumbers.value = include
+    }
+
+    fun updateUseCapitalization(use: Boolean) {
+        _useCapitalization.value = use
+    }
+
+    private fun generateUsername(
+        includeNumbers: Boolean = true,
+        useCapitalization: Boolean = true
+    ): String {
+        var adjective = adjectives.random()
+        var noun = nouns.random()
+        val numberPart =
+            if (includeNumbers)
+                Random.nextInt(100, 1000).toString()
+            else ""
+        if (useCapitalization) {
+            adjective = adjective.replaceFirstChar { it.uppercase() }
+            noun = noun.replaceFirstChar { it.uppercase() }
+        }
+        val username = "$adjective$noun$numberPart"
+        return username
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
@@ -10,14 +10,14 @@ import kotlin.random.Random
 @HiltViewModel
 class UsernameGeneratorViewModel @Inject constructor() : ViewModel() {
 
-    private val adjectives = listOf(
+    private val adjectives = arrayOf(
         "happy", "sad", "brave", "clever", "swift", "calm", "lively", "shy", "witty", "bold",
         "cheerful", "gentle", "fierce", "nimble", "quiet", "energetic", "mysterious", "playful",
         "serene", "vibrant", "graceful", "mighty", "sneaky", "brilliant", "curious", "daring",
         "elegant", "faithful", "jovial", "keen", "loyal", "noble", "peaceful", "quick",
         "radiant", "steady", "trusty", "unique", "valiant", "wise", "zealous"
     )
-    private val nouns = listOf(
+    private val nouns = arrayOf(
         "ghost", "trumpet", "tiger", "falcon", "wizard", "panda", "rocket", "shadow", "lion", "otter",
         "eagle", "phoenix", "dragon", "wolf", "bear", "fox", "hawk", "jaguar", "leopard", "lynx",
         "shark", "whale", "dolphin", "penguin", "sparrow", "raven", "owl", "swan", "deer", "horse",

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGeneratorViewModel.kt
@@ -11,28 +11,17 @@ import kotlin.random.Random
 class UsernameGeneratorViewModel @Inject constructor() : ViewModel() {
 
     private val adjectives = listOf(
-        "Happy",
-        "Sad",
-        "Brave",
-        "Clever",
-        "Swift",
-        "Calm",
-        "Lively",
-        "Shy",
-        "Witty",
-        "Bold"
+        "Happy", "Sad", "Brave", "Clever", "Swift", "Calm", "Lively", "Shy", "Witty", "Bold",
+        "Cheerful", "Gentle", "Fierce", "Nimble", "Quiet", "Energetic", "Mysterious", "Playful",
+        "Serene", "Vibrant", "Graceful", "Mighty", "Sneaky", "Brilliant", "Curious", "Daring",
+        "Elegant", "Faithful", "Jovial", "Keen", "Loyal", "Noble", "Peaceful", "Quick",
+        "Radiant", "Steady", "Trusty", "Unique", "Valiant", "Wise", "Zealous"
     )
     private val nouns = listOf(
-        "Ghost",
-        "Trumpet",
-        "Tiger",
-        "Falcon",
-        "Wizard",
-        "Panda",
-        "Rocket",
-        "Shadow",
-        "Lion",
-        "Otter"
+        "Ghost", "Trumpet", "Tiger", "Falcon", "Wizard", "Panda", "Rocket", "Shadow", "Lion", "Otter",
+        "Eagle", "Phoenix", "Dragon", "Wolf", "Bear", "Fox", "Hawk", "Jaguar", "Leopard", "Lynx",
+        "Shark", "Whale", "Dolphin", "Penguin", "Sparrow", "Raven", "Owl", "Swan", "Deer", "Horse",
+        "Elephant", "Rhino", "Hippo", "Giraffe", "Zebra", "Kangaroo", "Koala", "Sloth", "Turtle", "Frog"
     )
 
     private val _username = MutableLiveData<String>()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="you_have_no_cards_saved_till_now">You have no Cards saved till now</string>
     <string name="empty_list">Empty List</string>
     <string name="my_passwords">My passwords</string>
+    <string name="generator">Generator</string>
     <string name="password_generator">Password Generator</string>
     <string name="include_numbers">Include numbers</string>
     <string name="include_lowercase_letters">Include lowercase letters</string>
@@ -200,6 +201,7 @@
     <string name="create_an_account">Create an account</string>
     <string name="tools">Tools</string>
     <string name="quickly_generate_your_new_secure_passwords">Quickly generate your new secure passwords</string>
+    <string name="quickly_generate_your_passwords_and_usernames">Quickly generate passwords and usernames.</string>
     <string name="password_health">Password Health</string>
     <string name="identify_passwords_health">Identify passwords health</string>
     <string name="strong_passwords">Strong Passwords</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="username_hint">johndoe</string>
     <string name="not_favourite">Not favourite</string>
     <string name="password_strength">Password Strength</string>
+    <string name="password_score">Password Score</string>
     <string name="communities">Communities</string>
     <string name="portfolio">Portfolio</string>
     <string name="communication">Communication</string>


### PR DESCRIPTION
This pull request introduces a new `GeneratorScreen` feature, allowing users to toggle between password and username generation. It also refactors the existing `PasswordGenerator` screen to improve functionality and UI, while making minor adjustments to navigation and supporting files.

### New Feature: Generator Screen

* Added a new `GeneratorScreen` with a segmented button UI to switch between "Password" and "Username" generation. The username generator currently displays a placeholder. (`app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt`)
* Updated navigation to include the `GeneratorScreen` with a `tab` argument for specifying the initial tab (default: "password"). (`app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt`)
* Added `GeneratorScreen` to the `Screen` sealed class for navigation. (`app/src/main/java/com/aritradas/uncrack/navigation/Screen.kt`)

### Enhancements to Password Generator

* Added password strength calculation and visual feedback via a color-coded line. The password's strength is dynamically updated based on its characteristics. (`app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt`) [[1]](diffhunk://#diff-cf77c1134739cdc554973d9f84568d75348d0356da28d04564a691db35867e38R72-L91) [[2]](diffhunk://#diff-cf77c1134739cdc554973d9f84568d75348d0356da28d04564a691db35867e38L116-R159)
* Simplified the UI by removing the top app bar and adding a button for copying generated passwords. (`app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt`) [[1]](diffhunk://#diff-cf77c1134739cdc554973d9f84568d75348d0356da28d04564a691db35867e38L142-L150) [[2]](diffhunk://#diff-cf77c1134739cdc554973d9f84568d75348d0356da28d04564a691db35867e38L175-L202)

### Navigation and UI Adjustments

* Modified `ToolsScreen` to navigate to the `GeneratorScreen` instead of the `PasswordGeneratorScreen`. Added a new row for "Username Generator" with a placeholder icon and description. (`app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt`) [[1]](diffhunk://#diff-b32e0a2f53915d46104f5f8e690e7836915a05bad7e07ad0a6fb32a31df448bdL63-R67) [[2]](diffhunk://#diff-b32e0a2f53915d46104f5f8e690e7836915a05bad7e07ad0a6fb32a31df448bdR107-R149)
* Updated strings to include a new label for "Password Score." (`app/src/main/res/values/strings.xml`)

### Related Issue:
Closes #283 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new Generator screen with tabs for password and username generation.
  - Added a username generator with options to include numbers and capitalization, plus generate and copy functionality.
  - Added navigation options to access the Generator screen directly.
- **Improvements**
  - Streamlined the password generator UI for a more intuitive experience, including automatic password generation and a visual strength indicator.
- **Other**
  - Added new string resources for "Generator", "Password Score", and "Quickly generate passwords and usernames."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->