### PR TITLE
Replace Hardcoded Colors with MaterialTheme for Theme Adaptability

### DIFF
--- a/app/src/main/java/com/aritradas/uncrack/components/AccountCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/AccountCard.kt
@@ -10,17 +10,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 import com.aritradas.uncrack.ui.theme.medium18
 
 @Composable
@@ -35,7 +34,7 @@ fun AccountCard(
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
             .clickable { onClick() }
-            .background(SurfaceVariantLight)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -49,7 +48,7 @@ fun AccountCard(
 
         Text(
             text = text,
-            style = medium18.copy(Color.Black)
+            style = medium18.copy(color = MaterialTheme.colorScheme.onSurface)
         )
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/components/AutoLockTimeoutDialog.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/AutoLockTimeoutDialog.kt
@@ -44,7 +44,7 @@ fun AutoLockTimeoutDialog(
         title = {
             Text(
                 text = stringResource(R.string.auto_lock_timeout),
-                style = normal16
+                style = normal16.copy(color = MaterialTheme.colorScheme.onBackground)
             )
         },
         text = {
@@ -71,7 +71,7 @@ fun AutoLockTimeoutDialog(
                         )
                         Text(
                             text = text,
-                            style = normal16,
+                            style = normal16.copy(color = MaterialTheme.colorScheme.onBackground),
                             modifier = Modifier
                                 .padding(start = 8.dp)
                         )
@@ -92,7 +92,7 @@ fun AutoLockTimeoutDialog(
             ) {
                 Text(
                     stringResource(R.string.save),
-                    style = medium14
+                    style = medium14.copy(color = MaterialTheme.colorScheme.primary)
                 )
             }
         },
@@ -106,7 +106,7 @@ fun AutoLockTimeoutDialog(
             ) {
                 Text(
                     stringResource(R.string.cancel),
-                    style = medium14
+                    style = medium14.copy(color = MaterialTheme.colorScheme.primary)
                 )
             }
         },

--- a/app/src/main/java/com/aritradas/uncrack/components/CategoryCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/CategoryCard.kt
@@ -11,19 +11,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.aritradas.uncrack.R
-import com.aritradas.uncrack.ui.theme.PrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.normal12
 
 @Composable
@@ -48,8 +47,12 @@ fun CategoryCard(
                 .widthIn(min = 100.dp, 100.dp)
                 .heightIn(min = 100.dp, 100.dp)
                 .clip(RoundedCornerShape(10.dp))
-                .background(PrimaryContainerLight)
-                .border(width = 1.dp, color = Color(0xFFEEEEEE), RoundedCornerShape(12.dp)),
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    shape = RoundedCornerShape(12.dp)
+                ),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
@@ -67,7 +70,7 @@ fun CategoryCard(
             Text(
                 modifier = Modifier.padding(top = 11.dp),
                 text = text,
-                style = normal12.copy(Color.Black),
+                style = normal12.copy(MaterialTheme.colorScheme.onPrimaryContainer),
                 maxLines = 1
             )
         }

--- a/app/src/main/java/com/aritradas/uncrack/components/EmptyState.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/EmptyState.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.aritradas.uncrack.ui.theme.OnSurfaceVariantLight
 import com.aritradas.uncrack.ui.theme.medium22
 
 @Composable
@@ -22,22 +22,18 @@ fun EmptyState(
     image: Int,
     modifier: Modifier = Modifier
 ) {
-
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-
         Image(painter = painterResource(id = image), contentDescription = null)
-
         Spacer(modifier = Modifier.height(10.dp))
-
         Text(
             text = stateTitle,
             textAlign = TextAlign.Center,
             style = medium22,
-            color = OnSurfaceVariantLight
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/components/NoInternetScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/NoInternetScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,7 +36,6 @@ fun NoInternetScreen(modifier: Modifier = Modifier) {
         isPlaying = true
     )
 
-
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
@@ -52,14 +52,14 @@ fun NoInternetScreen(modifier: Modifier = Modifier) {
 
         Text(
             text = "Opps Network Error!",
-            style = bold30
+            style = bold30.copy(color = MaterialTheme.colorScheme.onBackground)
         )
 
         Spacer(modifier = Modifier.height(5.dp))
 
         Text(
             text = "Please try again later",
-            style = normal20
+            style = normal20.copy(color = MaterialTheme.colorScheme.onBackground)
         )
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/components/OnboardingComponent.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/OnboardingComponent.kt
@@ -4,14 +4,13 @@ import androidx.compose.runtime.Composable
 import com.aritradas.uncrack.presentation.intro.model.OnBoardingItem
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.bold22
 import com.aritradas.uncrack.ui.theme.medium16
 
@@ -34,7 +33,7 @@ fun OnboardingComponent(item: OnBoardingItem, modifier: Modifier = Modifier) {
         Text(
             modifier = Modifier.padding(horizontal = 30.dp),
             text = item.title,
-            style = bold22.copy(OnPrimaryContainerLight),
+            style = bold22.copy(color = MaterialTheme.colorScheme.onPrimaryContainer),
             textAlign = TextAlign.Center
         )
 
@@ -44,7 +43,7 @@ fun OnboardingComponent(item: OnBoardingItem, modifier: Modifier = Modifier) {
             modifier = Modifier.padding(horizontal = 30.dp),
             text = item.text,
             textAlign = TextAlign.Center,
-            style = medium16.copy(SurfaceTintLight)
+            style = medium16.copy(color = MaterialTheme.colorScheme.surfaceTint)
         )
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/components/PasswordCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/PasswordCard.kt
@@ -11,20 +11,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.medium16
 import com.aritradas.uncrack.ui.theme.normal12
 
@@ -37,7 +36,7 @@ private fun PasswordCard(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
-            .background(Color.White)
+            .background(MaterialTheme.colorScheme.surface)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
@@ -58,7 +57,7 @@ private fun PasswordCard(
         ) {
             Text(
                 text = "Instagram",
-                color = OnPrimaryContainerLight,
+                color = MaterialTheme.colorScheme.onSurface,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
                 style = medium16
@@ -69,7 +68,7 @@ private fun PasswordCard(
             Text(
                 modifier = Modifier.alpha(0.75f),
                 text = stringResource(id = R.string.email_hint),
-                color = OnPrimaryContainerLight,
+                color = MaterialTheme.colorScheme.onSurface,
                 style = normal12
             )
         }

--- a/app/src/main/java/com/aritradas/uncrack/components/ProfileContainer.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/ProfileContainer.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -20,8 +21,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.sharedViewModel.UserViewModel
-import com.aritradas.uncrack.ui.theme.PrimaryLight
-import com.aritradas.uncrack.ui.theme.SurfaceLight
 import com.aritradas.uncrack.ui.theme.bold24
 
 @Composable
@@ -29,7 +28,6 @@ fun ProfileContainer(
     userViewModel: UserViewModel,
     modifier: Modifier = Modifier
 ) {
-
     var initials by remember { mutableStateOf("") }
     val userData by userViewModel.state.collectAsState()
 
@@ -40,7 +38,7 @@ fun ProfileContainer(
         modifier = modifier
             .size(100.dp)
             .clip(CircleShape)
-            .background(PrimaryLight)
+            .background(MaterialTheme.colorScheme.primary)
     ) {
         if (initials.isEmpty()) {
             Image(
@@ -51,7 +49,7 @@ fun ProfileContainer(
         } else {
             Text(
                 text = initials,
-                style = bold24.copy(SurfaceLight)
+                style = bold24.copy(color = MaterialTheme.colorScheme.onPrimary)
             )
         }
     }

--- a/app/src/main/java/com/aritradas/uncrack/components/ProgressDialog.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/ProgressDialog.kt
@@ -1,6 +1,5 @@
 package com.aritradas.uncrack.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,12 +12,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.aritradas.uncrack.R
-import com.aritradas.uncrack.ui.theme.DMSansFontFamily
 
 @Composable
 fun ProgressDialog(
@@ -33,13 +30,9 @@ fun ProgressDialog(
         )
     ) {
         Surface(
-            modifier = Modifier
-                .background(
-                    MaterialTheme.colorScheme.surfaceContainer,
-                    shape = MaterialTheme.shapes.medium
-                )
-                .then(modifier),
-            shape = MaterialTheme.shapes.medium
+            modifier = modifier,
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.surfaceContainer
         ) {
             Column(
                 modifier = Modifier
@@ -53,7 +46,8 @@ fun ProgressDialog(
                 )
                 Text(
                     text = stringResource(R.string.please_wait),
-                    style = TextStyle(fontFamily = DMSansFontFamily)
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             }
         }

--- a/app/src/main/java/com/aritradas/uncrack/components/SettingsItemGroup.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/SettingsItemGroup.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,7 +25,7 @@ fun SettingsItemGroup(
             .widthIn(max = 500.dp)
             .padding(horizontal = 12.dp)
             .clip(RoundedCornerShape(10.dp))
-            .background(SurfaceVariantLight),
+            .background(MaterialTheme.colorScheme.onSurfaceVariant),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         columnScope()

--- a/app/src/main/java/com/aritradas/uncrack/components/SettingsItemGroup.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/SettingsItemGroup.kt
@@ -12,8 +12,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 
 @Composable
 fun SettingsItemGroup(

--- a/app/src/main/java/com/aritradas/uncrack/components/ShieldCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/ShieldCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,18 +16,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 import com.aritradas.uncrack.ui.theme.medium18
 import com.aritradas.uncrack.ui.theme.medium26
 import com.aritradas.uncrack.ui.theme.normal14
-import com.aritradas.uncrack.ui.theme.strongPassword
 
 @Composable
 fun ShieldCard(
     count: Int,
     modifier: Modifier = Modifier,
-    textColor: Color = strongPassword,
+    textColor: Color = MaterialTheme.colorScheme.primary,
     text: String = "",
     subText: String = ""
 ) {
@@ -34,7 +32,7 @@ fun ShieldCard(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
-            .background(SurfaceVariantLight)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
             .shadow(
                 elevation = 5.dp,
                 spotColor = Color(0x0D666666),
@@ -55,7 +53,7 @@ fun ShieldCard(
 
             Text(
                 text = subText,
-                style = normal14.copy(SurfaceTintLight)
+                style = normal14.copy(color = MaterialTheme.colorScheme.surfaceTint)
             )
 
             Text(

--- a/app/src/main/java/com/aritradas/uncrack/components/ThemeDialog.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/ThemeDialog.kt
@@ -22,19 +22,18 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
-import com.aritradas.uncrack.ui.theme.light16
-import com.aritradas.uncrack.ui.theme.medium14
-import com.aritradas.uncrack.ui.theme.normal24
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ThemeDialog(
     modifier: Modifier = Modifier,
-    onDismissRequest: () -> Unit
+    onDismissRequest: () -> Unit,
+    onDarkMode: () -> Unit,
+    onLightMode: () -> Unit,
+    onDynamicMode: () -> Unit
 ) {
-
     BasicAlertDialog(
-        onDismissRequest = { onDismissRequest() }
+        onDismissRequest = onDismissRequest
     ) {
         Column(
             modifier
@@ -43,7 +42,6 @@ fun ThemeDialog(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.themes),
                 contentDescription = null,
@@ -52,53 +50,49 @@ fun ThemeDialog(
 
             Text(
                 text = "Change Theme",
-                style = normal24.copy(MaterialTheme.colorScheme.onSurface)
+                style = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.onSurface)
             )
 
             Column {
-
-
                 Text(
                     text = "Dark Mode",
                     modifier = Modifier
                         .clickable {
-                            // TODO: Impl the logic
+                            onDarkMode()
                             onDismissRequest()
                         }
                         .fillMaxWidth()
                         .padding(vertical = 16.dp, horizontal = 32.dp),
-                    style = light16.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
+                    style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
                 )
 
                 Text(
                     text = "Light Mode",
                     modifier = Modifier
                         .clickable {
-                            // TODO: Impl the logic
+                            onLightMode()
                             onDismissRequest()
                         }
                         .fillMaxWidth()
                         .padding(vertical = 16.dp, horizontal = 32.dp),
-                    style = light16.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
+                    style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
                 )
 
                 Text(
                     text = "Dynamic Theme",
                     modifier = Modifier
                         .clickable {
-                            // TODO: Impl the logic
+                            onDynamicMode()
                             onDismissRequest()
                         }
                         .fillMaxWidth()
                         .padding(vertical = 16.dp, horizontal = 32.dp),
-                    style = light16.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
+                    style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
                 )
             }
 
             TextButton(
-                onClick = {
-                    onDismissRequest()
-                },
+                onClick = onDismissRequest,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Color.Transparent,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer
@@ -109,7 +103,7 @@ fun ThemeDialog(
             ) {
                 Text(
                     text = "Dismiss",
-                    style = medium14
+                    style = MaterialTheme.typography.labelLarge
                 )
             }
         }

--- a/app/src/main/java/com/aritradas/uncrack/components/TypeWritingText.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/TypeWritingText.kt
@@ -1,5 +1,6 @@
 package com.aritradas.uncrack.components
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -9,7 +10,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.aritradas.uncrack.ui.theme.OnSurfaceVariantLight
 import com.aritradas.uncrack.ui.theme.normal16
 import kotlinx.coroutines.delay
 import kotlin.streams.toList
@@ -19,27 +19,18 @@ fun TypewriterText(
     texts: List<String>,
     modifier: Modifier = Modifier,
 ) {
-    var textIndex by remember {
-        mutableIntStateOf(0)
-    }
-    var textToDisplay by remember {
-        mutableStateOf("")
-    }
+    var textIndex by remember { mutableIntStateOf(0) }
+    var textToDisplay by remember { mutableStateOf("") }
     val textCharsList: List<List<String>> = remember {
-        texts.map {
-            it.splitToCodePoints()
-        }
+        texts.map { it.splitToCodePoints() }
     }
 
     LaunchedEffect(key1 = texts) {
         while (textIndex < textCharsList.size) {
             textCharsList[textIndex].forEachIndexed { charIndex, _ ->
                 textToDisplay = textCharsList[textIndex]
-                    .take(
-                        n = charIndex + 1
-                    ).joinToString(
-                        separator = ""
-                    )
+                    .take(charIndex + 1)
+                    .joinToString(separator = "")
                 delay(160)
             }
             textIndex = (textIndex + 1) % texts.size
@@ -50,14 +41,12 @@ fun TypewriterText(
     Text(
         modifier = modifier,
         text = textToDisplay,
-        style = normal16.copy(OnSurfaceVariantLight),
+        style = normal16.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
     )
 }
 
 fun String.splitToCodePoints(): List<String> {
     return codePoints()
         .toList()
-        .map {
-            String(Character.toChars(it))
-        }
+        .map { String(Character.toChars(it)) }
 }

--- a/app/src/main/java/com/aritradas/uncrack/components/UCButton.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/UCButton.kt
@@ -8,17 +8,15 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
-import com.aritradas.uncrack.ui.theme.PrimaryLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 
 @Composable
 fun UCButton(
@@ -41,21 +39,24 @@ fun UCButton(
             .then(modifier),
         onClick = { onClick() },
         colors = ButtonDefaults.buttonColors(
-            containerColor = PrimaryLight
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
         ),
         enabled = enabled && !isLoading
     ) {
         if (isLoading) {
             CircularProgressIndicator(
                 modifier = Modifier.size(24.dp),
-                color = Color.Black,
+                color = MaterialTheme.colorScheme.onSurface,
                 strokeWidth = 2.dp
             )
             loadingText?.let {
                 Text(
                     modifier = Modifier.padding(start = 8.dp),
                     text = it,
-                    color = Color.Black,
+                    color = MaterialTheme.colorScheme.onSurface,
                     fontFamily = DMSansFontFamily,
                     fontSize = 14.sp
                 )
@@ -70,7 +71,7 @@ fun UCButton(
             }
             Text(
                 text = text,
-                color = if (enabled) Color.White else SurfaceTintLight,
+                color = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
                 fontFamily = DMSansFontFamily,
                 fontSize = 14.sp
             )

--- a/app/src/main/java/com/aritradas/uncrack/components/UCSettingsCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/UCSettingsCard.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
-import com.aritradas.uncrack.ui.theme.OnSurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.medium18
 import com.aritradas.uncrack.ui.theme.normal14
 

--- a/app/src/main/java/com/aritradas/uncrack/components/UCSettingsCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/UCSettingsCard.kt
@@ -1,5 +1,6 @@
 package com.aritradas.uncrack.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,13 +32,14 @@ fun UCSettingsCard(
     itemSubText: String? = null,
     modifier: Modifier = Modifier,
     iconId: Int? = null,
-    textColor: Color = OnSurfaceLight,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
     onClick: () -> Unit
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onClick() }
+            .background(MaterialTheme.colorScheme.surface)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -63,7 +66,7 @@ fun UCSettingsCard(
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = itemSubText,
-                    style = normal14.copy(SurfaceTintLight)
+                    style = normal14.copy(MaterialTheme.colorScheme.onSurfaceVariant)
                 )
             }
         }

--- a/app/src/main/java/com/aritradas/uncrack/components/UCStrokeButton.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/UCStrokeButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,15 +17,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.aritradas.uncrack.ui.theme.BackgroundDark
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
 
 @Composable
 fun UCStrokeButton(
     text: String,
     modifier: Modifier = Modifier,
-    strokeColor: Color = BackgroundDark,
-    textColor: Color = BackgroundDark,
+    strokeColor: Color = MaterialTheme.colorScheme.primary,
+    textColor: Color = MaterialTheme.colorScheme.primary,
     leadingIcon: Painter? = null,
     enabled: Boolean = true,
     onClick: () -> Unit
@@ -40,7 +40,11 @@ fun UCStrokeButton(
         onClick = { onClick() },
         shape = CircleShape,
         enabled = enabled,
-        border = BorderStroke(1.dp, strokeColor)
+        border = BorderStroke(1.dp, strokeColor),
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = textColor,
+            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     ) {
         leadingIcon?.let {
             Icon(

--- a/app/src/main/java/com/aritradas/uncrack/components/UCSwitchCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/UCSwitchCard.kt
@@ -1,11 +1,8 @@
 package com.aritradas.uncrack.components
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,23 +12,22 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.aritradas.uncrack.ui.theme.OnSurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.medium18
 import com.aritradas.uncrack.ui.theme.normal14
 
 @Composable
 fun UCSwitchCard(
     itemName: String,
-    itemSubText: String? = null,
     isChecked: Boolean,
     modifier: Modifier = Modifier,
-    textColor: Color = OnSurfaceLight,
+    itemSubText: String? = null,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
     onChecked: (Boolean) -> Unit
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -41,15 +37,14 @@ fun UCSwitchCard(
         ) {
             Text(
                 text = itemName,
-                style = medium18.copy(textColor)
+                style = medium18.copy(color = textColor)
             )
 
             if (!itemSubText.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(4.dp))
-
                 Text(
                     text = itemSubText,
-                    style = normal14.copy(SurfaceTintLight)
+                    style = normal14.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
                 )
             }
         }

--- a/app/src/main/java/com/aritradas/uncrack/components/UCTextField.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/UCTextField.kt
@@ -1,13 +1,10 @@
 package com.aritradas.uncrack.components
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -23,10 +20,6 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.OnSurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 import com.aritradas.uncrack.ui.theme.normal16
 
 @Composable
@@ -38,8 +31,8 @@ fun UCTextField(
     keyboardType: KeyboardType = KeyboardType.Text,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-    textColor: Color = OnSurfaceLight,
-    backgroundColor: Color = SurfaceVariantLight,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
     textStyle: TextStyle = normal16,
     enabled: Boolean = true,
     singleLine: Boolean = false,
@@ -78,8 +71,9 @@ fun UCTextField(
             minLines = minLines,
             leadingIcon = leadingIcon,
             visualTransformation = visualTransformation,
-            trailingIcon = trailingIcon
-        ) { onValueChange(it) } // Use String instead of MutableState<String>
+            trailingIcon = trailingIcon,
+            onValueChange = onValueChange
+        )
     }
 }
 
@@ -93,7 +87,7 @@ fun TextHeader(text: String, modifier: Modifier = Modifier) {
             lineHeight = 24.sp,
             fontFamily = DMSansFontFamily,
             fontWeight = FontWeight(500),
-            color = OnPrimaryContainerLight,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
         )
     )
 }
@@ -106,8 +100,8 @@ fun TextEditField(
     hintText: String = "",
     value: String = "",
     keyboardActions: KeyboardActions = KeyboardActions.Default,
-    textColor: Color = OnSurfaceLight,
-    backgroundColor: Color = SurfaceVariantLight,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
     keyboardType: KeyboardType = KeyboardType.Text,
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = keyboardType),
     textStyle: TextStyle = normal16,
@@ -124,16 +118,27 @@ fun TextEditField(
         modifier = modifier.fillMaxWidth(),
         value = value,
         keyboardOptions = keyboardOptions,
-        onValueChange = {
-            onValueChange(it)
-        },
+        onValueChange = onValueChange,
         keyboardActions = keyboardActions,
-        colors = OutlinedTextFieldDefaults.colors(textColor),
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedTextColor = textColor,
+            unfocusedTextColor = textColor,
+            disabledTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            focusedContainerColor = backgroundColor,
+            unfocusedContainerColor = backgroundColor,
+            disabledContainerColor = backgroundColor,
+            cursorColor = MaterialTheme.colorScheme.primary,
+            focusedBorderColor = MaterialTheme.colorScheme.primary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+            disabledBorderColor = MaterialTheme.colorScheme.outlineVariant,
+            errorBorderColor = MaterialTheme.colorScheme.error,
+            errorCursorColor = MaterialTheme.colorScheme.error
+        ),
         placeholder = {
             Text(
                 modifier = Modifier.wrapContentHeight(align = Alignment.CenterVertically),
                 text = hintText,
-                color = SurfaceTintLight,
+                color = MaterialTheme.colorScheme.surfaceTint,
                 fontFamily = DMSansFontFamily
             )
         },

--- a/app/src/main/java/com/aritradas/uncrack/components/UCTopAppBar.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/UCTopAppBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
@@ -18,8 +19,6 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
-import com.aritradas.uncrack.ui.theme.OnSurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,7 +29,12 @@ fun UCTopAppBar(
     shouldShowBackButton: Boolean = true,
     shouldShowFavAndEditButton: Boolean = true,
     fontSize: TextUnit = 22.sp,
-    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(SurfaceVariantLight),
+    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(
+        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        titleContentColor = MaterialTheme.colorScheme.onSurface,
+        navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+        actionIconContentColor = MaterialTheme.colorScheme.onSurface
+    ),
     onBackPress: () -> Unit = {},
     onEditPress: () -> Unit = {},
     onDeletePress: () -> Unit = {}
@@ -42,16 +46,14 @@ fun UCTopAppBar(
                 text = title,
                 fontFamily = DMSansFontFamily,
                 fontSize = fontSize,
-                color = OnSurfaceLight,
+                color = MaterialTheme.colorScheme.onSurface,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
             )
         },
         navigationIcon = {
             if (shouldShowBackButton) {
-                IconButton(onClick = {
-                    onBackPress()
-                }) {
+                IconButton(onClick = { onBackPress() }) {
                     Icon(
                         imageVector = navigationIcon,
                         contentDescription = null
@@ -60,16 +62,14 @@ fun UCTopAppBar(
             }
         },
         actions = {
-            if (shouldShowFavAndEditButton.not()) {
-                IconButton(onClick = {
-                    onEditPress()
-                }) {
-                    Icon(painter = painterResource(id = R.drawable.edit), contentDescription = null)
+            if (!shouldShowFavAndEditButton) {
+                IconButton(onClick = { onEditPress() }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.edit),
+                        contentDescription = null
+                    )
                 }
-
-                IconButton(onClick = {
-                    onDeletePress()
-                }) {
+                IconButton(onClick = { onDeletePress() }) {
                     Icon(
                         painter = painterResource(id = R.drawable.delete_icon),
                         contentDescription = null

--- a/app/src/main/java/com/aritradas/uncrack/components/VaultCard.kt
+++ b/app/src/main/java/com/aritradas/uncrack/components/VaultCard.kt
@@ -8,14 +8,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.domain.model.Account
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.medium18
 import com.aritradas.uncrack.ui.theme.normal14
 import com.aritradas.uncrack.util.EncryptionUtils
@@ -27,7 +26,6 @@ fun VaultCard(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-
     val email = try {
         EncryptionUtils.decrypt(accountModel.email)
     } catch (e: Exception) {
@@ -51,12 +49,12 @@ fun VaultCard(
         Column {
             Text(
                 text = accountModel.company,
-                style = medium18.copy(Color.Black)
+                style = medium18.copy(color = MaterialTheme.colorScheme.onSurface)
             )
 
             Text(
                 text = email,
-                style = normal14.copy(SurfaceTintLight)
+                style = normal14.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
             )
         }
     }

--- a/app/src/main/java/com/aritradas/uncrack/data/datastore/DataStoreUtil.kt
+++ b/app/src/main/java/com/aritradas/uncrack/data/datastore/DataStoreUtil.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import javax.inject.Inject
 
@@ -14,7 +15,7 @@ class DataStoreUtil @Inject constructor(context: Context) {
 
     companion object {
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("settings")
-        val IS_DARK_MODE_KEY = booleanPreferencesKey("dark_mode")
+        val THEME_MODE_KEY = stringPreferencesKey("theme_mode")
         val IS_SS_BLOCK_KEY = booleanPreferencesKey("ss_block")
         val IS_BIOMETRIC_AUTH_SET_KEY = booleanPreferencesKey("biometric_auth")
         val IS_AUTO_LOCK_ENABLED_KEY = booleanPreferencesKey("auto_lock_enabled")

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -393,7 +393,7 @@ fun ShowBottomNavigation(
                         }
                     },
                     colors = NavigationBarItemDefaults.colors(
-                        indicatorColor = MaterialTheme.colorScheme.primaryContainer
+                        indicatorColor = MaterialTheme.colorScheme.primary
                     )
                 )
             }

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -393,7 +393,7 @@ fun ShowBottomNavigation(
                         }
                     },
                     colors = NavigationBarItemDefaults.colors(
-                        indicatorColor = MaterialTheme.colorScheme.primary
+                        indicatorColor = MaterialTheme.colorScheme.primaryContainer
                     )
                 )
             }

--- a/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
+++ b/app/src/main/java/com/aritradas/uncrack/navigation/Navigation.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresApi
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
@@ -66,10 +67,6 @@ import com.aritradas.uncrack.sharedViewModel.UserViewModel
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
 import com.aritradas.uncrack.ui.theme.FadeIn
 import com.aritradas.uncrack.ui.theme.FadeOut
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.OnSurfaceVariantLight
-import com.aritradas.uncrack.ui.theme.PrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.PrimaryDark
 import com.aritradas.uncrack.util.BackPressHandler
 import com.aritradas.uncrack.util.ConnectivityObserver
 import kotlinx.collections.immutable.ImmutableList
@@ -319,7 +316,7 @@ fun ShowBottomNavigation(
     if (backStackEntry?.destination?.route !in screensWithoutNavigationBar) {
         NavigationBar(
             modifier = modifier,
-            containerColor = PrimaryContainerLight
+            containerColor = MaterialTheme.colorScheme.primaryContainer
         ) {
 
             val bottomNavItems = listOf(
@@ -360,9 +357,9 @@ fun ShowBottomNavigation(
                             imageVector = item.icon,
                             contentDescription = item.name,
                             tint = if (isSelected)
-                                OnPrimaryContainerLight
+                                MaterialTheme.colorScheme.onPrimaryContainer
                             else
-                                OnSurfaceVariantLight
+                                MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     },
                     label = {
@@ -370,9 +367,9 @@ fun ShowBottomNavigation(
                             text = item.name,
                             fontFamily = DMSansFontFamily,
                             color = if (isSelected)
-                                OnPrimaryContainerLight
+                                MaterialTheme.colorScheme.onPrimaryContainer
                             else
-                                OnSurfaceVariantLight,
+                                MaterialTheme.colorScheme.onSurfaceVariant,
                             fontWeight = if (isSelected)
                                 FontWeight.SemiBold
                             else
@@ -396,7 +393,7 @@ fun ShowBottomNavigation(
                         }
                     },
                     colors = NavigationBarItemDefaults.colors(
-                        indicatorColor = PrimaryDark
+                        indicatorColor = MaterialTheme.colorScheme.primary
                     )
                 )
             }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/auth/forgotPassword/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/auth/forgotPassword/ForgotPasswordScreen.kt
@@ -2,6 +2,7 @@ package com.aritradas.uncrack.presentation.auth.forgotPassword
 
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -96,6 +98,7 @@ fun ForgotPasswordScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues)
+                        .background(MaterialTheme.colorScheme.background)
                         .padding(16.dp)
                 ) {
 
@@ -104,7 +107,7 @@ fun ForgotPasswordScreen(
                         fontSize = 40.sp,
                         fontWeight = FontWeight.Bold,
                         fontFamily = DMSansFontFamily,
-                        color = Color.Black
+                        color = MaterialTheme.colorScheme.onBackground
                     )
 
                     Spacer(modifier = Modifier.height(60.dp))

--- a/app/src/main/java/com/aritradas/uncrack/presentation/auth/forgotPassword/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/auth/forgotPassword/ForgotPasswordScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight

--- a/app/src/main/java/com/aritradas/uncrack/presentation/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/auth/login/LoginScreen.kt
@@ -48,7 +48,6 @@ import com.aritradas.uncrack.components.UCButton
 import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.auth.AuthViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
 import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.PrimaryLight
@@ -111,7 +110,7 @@ fun LoginScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(BackgroundLight)
+                        .background(MaterialTheme.colorScheme.background)
                         .padding(paddingValues)
                         .padding(16.dp)
                 ) {
@@ -120,7 +119,7 @@ fun LoginScreen(
                         fontSize = 40.sp,
                         fontWeight = FontWeight.Bold,
                         fontFamily = DMSansFontFamily,
-                        color = Color.Black
+                        color = MaterialTheme.colorScheme.onBackground
                     )
 
                     Spacer(modifier = Modifier.height(60.dp))
@@ -196,7 +195,7 @@ fun LoginScreen(
                     ) {
                         Text(
                             text = stringResource(R.string.don_t_have_an_account),
-                            style = medium16.copy(color = OnPrimaryContainerLight)
+                            style = medium16.copy(color = MaterialTheme.colorScheme.onPrimaryContainer)
                         )
 
                         Spacer(modifier = Modifier.width(8.dp))
@@ -204,7 +203,7 @@ fun LoginScreen(
                         Text(
                             modifier = Modifier.clickable { navController.navigate(Screen.SignUpScreen.name) },
                             text = stringResource(R.string.create),
-                            style = medium16.copy(color = PrimaryLight)
+                            style = medium16.copy(color = MaterialTheme.colorScheme.primary)
                         )
                     }
                 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/auth/login/LoginScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -49,8 +48,6 @@ import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.auth.AuthViewModel
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.PrimaryLight
 import com.aritradas.uncrack.ui.theme.medium16
 import com.aritradas.uncrack.util.ConnectivityObserver
 import com.aritradas.uncrack.util.Validator.Companion.isValidEmail

--- a/app/src/main/java/com/aritradas/uncrack/presentation/auth/signup/SignupScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/auth/signup/SignupScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -121,17 +122,16 @@ fun SignupScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(BackgroundLight)
+                        .background(MaterialTheme.colorScheme.background)
                         .padding(paddingValues)
                         .padding(16.dp)
                 ) {
-
                     Text(
                         text = stringResource(R.string.sign_up),
                         fontSize = 40.sp,
                         fontWeight = FontWeight.Bold,
                         fontFamily = DMSansFontFamily,
-                        color = Color.Black
+                        color = MaterialTheme.colorScheme.onBackground
                     )
 
                     Spacer(modifier = Modifier.height(60.dp))
@@ -226,17 +226,15 @@ fun SignupScreen(
                     ) {
                         Text(
                             text = stringResource(id = R.string.already_have_an_account),
-                            style = medium16.copy(color = OnPrimaryContainerLight)
+                            style = medium16.copy(color = MaterialTheme.colorScheme.onPrimaryContainer)
                         )
-
                         Spacer(modifier = Modifier.width(8.dp))
-
                         Text(
                             modifier = Modifier.clickable {
                                 navController.navigate(Screen.LoginScreen.name)
                             },
                             text = stringResource(id = R.string.login),
-                            style = medium16.copy(color = PrimaryLight)
+                            style = medium16.copy(color = MaterialTheme.colorScheme.primary)
                         )
                     }
                 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/auth/signup/SignupScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/auth/signup/SignupScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -47,10 +46,7 @@ import com.aritradas.uncrack.components.UCButton
 import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.auth.AuthViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.DMSansFontFamily
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.PrimaryLight
 import com.aritradas.uncrack.ui.theme.medium16
 import com.aritradas.uncrack.util.ConnectivityObserver
 import com.aritradas.uncrack.util.Validator.Companion.isValidEmail

--- a/app/src/main/java/com/aritradas/uncrack/presentation/browse/BrowseScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/browse/BrowseScreen.kt
@@ -14,14 +14,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.CategoryCard
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 import com.aritradas.uncrack.ui.theme.medium28
 import com.aritradas.uncrack.ui.theme.normal22
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/browse/BrowseScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/browse/BrowseScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,13 +39,13 @@ fun BrowseScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(SurfaceVariantLight)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
                 .padding(16.dp)
         ) {
 
             Text(
                 text = stringResource(R.string.browse),
-                style = medium28.copy(OnPrimaryContainerLight)
+                style = medium28.copy(MaterialTheme.colorScheme.onPrimaryContainer)
             )
 
             Spacer(modifier = Modifier.height(20.dp))
@@ -55,25 +56,19 @@ fun BrowseScreen(
                 CategoryCard(
                     icon = R.drawable.category_social,
                     text = stringResource(id = R.string.social),
-                    onClick = {
-
-                    }
+                    onClick = { }
                 )
 
                 CategoryCard(
                     icon = R.drawable.category_brower,
                     text = stringResource(R.string.browser),
-                    onClick = {
-
-                    }
+                    onClick = { }
                 )
 
                 CategoryCard(
                     icon = R.drawable.category_card,
                     text = stringResource(R.string.card),
-                    onClick = {
-
-                    }
+                    onClick = { }
                 )
             }
 
@@ -81,7 +76,7 @@ fun BrowseScreen(
 
             Text(
                 text = stringResource(R.string.recently_used),
-                style = normal22.copy(Color.Black)
+                style = normal22.copy(MaterialTheme.colorScheme.onBackground)
             )
 
             // TODO: FAV list

--- a/app/src/main/java/com/aritradas/uncrack/presentation/browse/category/CategoryScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/browse/category/CategoryScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.aritradas.uncrack.components.UCTopAppBar
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/aritradas/uncrack/presentation/browse/category/CategoryScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/browse/category/CategoryScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -34,7 +35,7 @@ fun CategoryScreen(
                 .fillMaxWidth()
                 .padding(paddingValues)
                 .padding(16.dp)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
         ) {
 
         }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/intro/OnboardingScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/intro/OnboardingScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -71,7 +72,7 @@ fun OnboardingScreen(
                         navController.navigate(Screen.LoginScreen.name)
                     },
                 text = stringResource(R.string.skip),
-                style = medium18.copy(OnSurfaceLight)
+                style = medium18.copy(MaterialTheme.colorScheme.onSurface)
             )
         }
 
@@ -119,8 +120,8 @@ fun PageIndicator(
     pagesSize: Int,
     selectedPage: Int,
     modifier: Modifier = Modifier,
-    selectedColor: Color = PrimaryDark,
-    unselectedColor: Color = OnSurfaceVariantLight
+    selectedColor: Color = MaterialTheme.colorScheme.primary,
+    unselectedColor: Color = MaterialTheme.colorScheme.onSurfaceVariant
 ) {
     Row(
         modifier = modifier,

--- a/app/src/main/java/com/aritradas/uncrack/presentation/intro/OnboardingScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/intro/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package com.aritradas.uncrack.presentation.intro
 
-import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -26,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -36,9 +34,6 @@ import com.aritradas.uncrack.components.UCButton
 import com.aritradas.uncrack.components.UCStrokeButton
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.intro.model.OnBoardingItem
-import com.aritradas.uncrack.ui.theme.OnSurfaceLight
-import com.aritradas.uncrack.ui.theme.OnSurfaceVariantLight
-import com.aritradas.uncrack.ui.theme.PrimaryDark
 import com.aritradas.uncrack.ui.theme.medium18
 
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/intro/SplashScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/intro/SplashScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.navigation.Screen
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.google.firebase.auth.FirebaseAuth
 
 @Composable

--- a/app/src/main/java/com/aritradas/uncrack/presentation/intro/SplashScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/intro/SplashScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -64,7 +65,7 @@ fun SplashScreen(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .background(BackgroundLight),
+                .background(MaterialTheme.colorScheme.background),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/confirmMasterKey/ConfirmMasterKeyScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/confirmMasterKey/ConfirmMasterKeyScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,7 +44,6 @@ import com.aritradas.uncrack.components.UCButton
 import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.masterKey.KeyViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.bold30
 import kotlinx.coroutines.delay
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/confirmMasterKey/ConfirmMasterKeyScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/confirmMasterKey/ConfirmMasterKeyScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -84,7 +85,7 @@ fun ConfirmMasterKeyScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .windowInsetsPadding(WindowInsets.ime)
         ) {
             Column(
@@ -96,7 +97,7 @@ fun ConfirmMasterKeyScreen(
 
                 Text(
                     text = stringResource(R.string.kindly_provide_your_master_password),
-                    style = bold30.copy(color = Color.Black)
+                    style = bold30.copy(color = MaterialTheme.colorScheme.onBackground)
                 )
 
                 Spacer(modifier = Modifier.height(50.dp))

--- a/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/createMasterKey/CreateMasterKeyScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/createMasterKey/CreateMasterKeyScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,19 +67,19 @@ fun CreateMasterKeyScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(16.dp)
         ) {
             Text(
                 text = stringResource(R.string.create_master_password),
-                style = bold30.copy(color = Color.Black)
+                style = bold30.copy(color = MaterialTheme.colorScheme.onBackground)
             )
 
             Spacer(modifier = Modifier.height(10.dp))
 
             Text(
                 text = stringResource(R.string.you_will_be_using_master_password_as_a_key_to_unlock_your_passwords),
-                style = normal16.copy(color = SurfaceTintLight)
+                style = normal16.copy(color = MaterialTheme.colorScheme.surfaceTint)
             )
 
             Spacer(modifier = Modifier.height(50.dp))
@@ -114,7 +115,7 @@ fun CreateMasterKeyScreen(
             ) {
                 Text(
                     text = stringResource(R.string.master_password_must_include),
-                    style = medium14.copy(OnPrimaryContainerLight)
+                    style = medium14.copy(MaterialTheme.colorScheme.onPrimaryContainer)
                 )
                 Spacer(modifier = Modifier.height(10.dp))
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/createMasterKey/CreateMasterKeyScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/createMasterKey/CreateMasterKeyScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -37,9 +36,6 @@ import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.domain.model.Key
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.masterKey.KeyViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.bold30
 import com.aritradas.uncrack.ui.theme.medium14
 import com.aritradas.uncrack.ui.theme.normal16

--- a/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/updateMasterKey/UpdateMasterKey.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/updateMasterKey/UpdateMasterKey.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -59,7 +60,7 @@ fun UpdateMasterKey(
             UCTopAppBar(
                 modifier = Modifier.fillMaxWidth(),
                 title = "Update Master Password",
-                colors = TopAppBarDefaults.topAppBarColors(SurfaceVariantLight),
+                colors = TopAppBarDefaults.topAppBarColors(MaterialTheme.colorScheme.surfaceVariant),
                 onBackPress = { navController.popBackStack() }
             )
         }
@@ -69,7 +70,7 @@ fun UpdateMasterKey(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(SurfaceVariantLight)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
                 .padding(16.dp)
         ) {
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/updateMasterKey/UpdateMasterKey.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/masterKey/updateMasterKey/UpdateMasterKey.kt
@@ -35,7 +35,6 @@ import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.components.UCTopAppBar
 import com.aritradas.uncrack.domain.model.Key
 import com.aritradas.uncrack.presentation.masterKey.KeyViewModel
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/aritradas/uncrack/presentation/profile/EditUsernameDialog.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/profile/EditUsernameDialog.kt
@@ -2,6 +2,7 @@ package com.aritradas.uncrack.presentation.profile
 
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -10,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.aritradas.uncrack.util.UtilsKt
+import androidx.compose.material3.TextFieldDefaults
 
 // Dialog to edit the username of the user
 @Composable
@@ -22,26 +24,49 @@ fun EditUsernameDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Edit Username") },
+        title = { Text("Edit Username", color = MaterialTheme.colorScheme.onSurface) },
         text = {
             TextField(
                 value = newName,
                 onValueChange = { newName = it },
-                singleLine = true
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.surface,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                    focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                    unfocusedIndicatorColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    cursorColor = MaterialTheme.colorScheme.primary
+                )
             )
         },
         confirmButton = {
             Button(
                 onClick = { onSave(newName) },
-                enabled = UtilsKt.validateName(newName)
+                enabled = UtilsKt.validateName(newName),
+                colors = androidx.compose.material3.ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
             ) {
                 Text("Save")
             }
         },
         dismissButton = {
-            Button(onClick = onDismiss) {
+            Button(
+                onClick = onDismiss,
+                colors = androidx.compose.material3.ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                )
+            ) {
                 Text("Cancel")
             }
         },
+        containerColor = MaterialTheme.colorScheme.surface,
+        titleContentColor = MaterialTheme.colorScheme.onSurface,
+        textContentColor = MaterialTheme.colorScheme.onSurface
     )
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/profile/HelpScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/profile/HelpScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -20,7 +21,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -28,8 +28,6 @@ import androidx.navigation.NavController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.SettingsItemGroup
 import com.aritradas.uncrack.components.UCSettingsCard
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 import com.aritradas.uncrack.util.Constants
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -49,22 +47,24 @@ fun HelpScreen(
                     Text(
                         text = "Help",
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.onBackground
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Localized description"
+                            contentDescription = "Localized description",
+                            tint = MaterialTheme.colorScheme.onBackground
                         )
                     }
                 },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = BackgroundLight,
-                    scrolledContainerColor = BackgroundLight,
-                    titleContentColor = Color.Black
+                    containerColor = MaterialTheme.colorScheme.background,
+                    scrolledContainerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground
                 )
             )
         }
@@ -73,7 +73,7 @@ fun HelpScreen(
             modifier = modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight),
+                .background(MaterialTheme.colorScheme.background),
         ) {
             SettingsItemGroup {
                 UCSettingsCard(
@@ -87,7 +87,7 @@ fun HelpScreen(
 
                 HorizontalDivider(
                     thickness = 2.dp,
-                    color = SurfaceVariantLight
+                    color = MaterialTheme.colorScheme.surfaceVariant
                 )
 
                 UCSettingsCard(
@@ -101,7 +101,7 @@ fun HelpScreen(
 
                 HorizontalDivider(
                     thickness = 2.dp,
-                    color = SurfaceVariantLight
+                    color = MaterialTheme.colorScheme.surfaceVariant
                 )
 
                 UCSettingsCard(

--- a/app/src/main/java/com/aritradas/uncrack/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/profile/ProfileScreen.kt
@@ -39,10 +39,6 @@ import com.aritradas.uncrack.components.SettingsItemGroup
 import com.aritradas.uncrack.components.UCSettingsCard
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.sharedViewModel.UserViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.OnSurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.medium22
 import com.aritradas.uncrack.ui.theme.normal14
 import com.aritradas.uncrack.util.Constants

--- a/app/src/main/java/com/aritradas/uncrack/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/profile/ProfileScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -52,7 +53,6 @@ fun ProfileScreen(
     userViewModel: UserViewModel,
     modifier: Modifier = Modifier
 ) {
-
     val context = LocalContext.current
     val userData by userViewModel.state.collectAsState()
     var showDialog by remember { mutableStateOf(false) }
@@ -66,14 +66,14 @@ fun ProfileScreen(
         modifier = modifier
             .fillMaxSize()
             .padding(top = paddingValues.calculateTopPadding() + 10.dp)
-            .background(BackgroundLight),
+            .background(MaterialTheme.colorScheme.background),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(BackgroundLight),
+                .background(MaterialTheme.colorScheme.background),
             verticalAlignment = Alignment.CenterVertically
         ) {
 
@@ -94,9 +94,8 @@ fun ProfileScreen(
                 ) {
                     Text(
                         text = userData.name,
-                        style = medium22.copy(color = OnSurfaceLight)
+                        style = medium22.copy(color = MaterialTheme.colorScheme.onSurface)
                     )
-                    // Button to open the dialog
                     IconButton(onClick = { showDialog = true }) {
                         Icon(
                             painter = painterResource(id = R.drawable.edit),
@@ -105,7 +104,6 @@ fun ProfileScreen(
                     }
                 }
 
-                // Initiates the dialog to edit the username
                 if (showDialog) {
                     EditUsernameDialog(
                         currentName = userData.name,
@@ -132,7 +130,7 @@ fun ProfileScreen(
 
             HorizontalDivider(
                 thickness = 2.dp,
-                color = SurfaceLight
+                color = MaterialTheme.colorScheme.surface
             )
 
             UCSettingsCard(
@@ -161,7 +159,7 @@ fun ProfileScreen(
 
             HorizontalDivider(
                 thickness = 2.dp,
-                color = SurfaceLight
+                color = MaterialTheme.colorScheme.surface
             )
 
             UCSettingsCard(
@@ -184,13 +182,12 @@ fun ProfileScreen(
         Text(
             modifier = Modifier.padding(top = 20.dp, bottom = 10.dp),
             text = "Version: ${BuildConfig.VERSION_NAME}",
-            style = normal14.copy(color = SurfaceTintLight)
+            style = normal14.copy(color = MaterialTheme.colorScheme.surfaceTint)
         )
         Text(
             modifier = Modifier.padding(bottom = 150.dp),
             text = stringResource(R.string.by_aritra_das),
-            style = normal14.copy(color = SurfaceTintLight)
+            style = normal14.copy(color = MaterialTheme.colorScheme.surfaceTint)
         )
-
     }
 }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -45,14 +47,13 @@ import com.aritradas.uncrack.components.ThemeDialog
 import com.aritradas.uncrack.components.UCSettingsCard
 import com.aritradas.uncrack.components.UCSwitchCard
 import com.aritradas.uncrack.navigation.Screen
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.OnSurfaceVariantLight
-import com.aritradas.uncrack.ui.theme.SurfaceLight
 import com.aritradas.uncrack.ui.theme.medium14
 import com.aritradas.uncrack.ui.theme.medium18
 import com.aritradas.uncrack.ui.theme.normal16
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.aritradas.uncrack.sharedViewModel.ThemeMode
 import com.aritradas.uncrack.sharedViewModel.ThemeViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -83,7 +84,12 @@ fun SettingsScreen(
 
     when {
         openThemeDialog -> {
-            ThemeDialog(onDismissRequest = { openThemeDialog = false })
+            ThemeDialog(
+                onDismissRequest = { openThemeDialog = false },
+                onDarkMode = { themeViewModel.setThemeMode(ThemeMode.DARK) },
+                onLightMode = { themeViewModel.setThemeMode(ThemeMode.LIGHT) },
+                onDynamicMode = { themeViewModel.setThemeMode(ThemeMode.SYSTEM) }
+            )
         }
 
         openAutoLockTimeoutDialog -> {
@@ -236,9 +242,9 @@ fun SettingsScreen(
                 },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = BackgroundLight,
-                    scrolledContainerColor = BackgroundLight,
-                    titleContentColor = Color.Black
+                    containerColor = MaterialTheme.colorScheme.background,
+                    scrolledContainerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground
                 )
             )
         }
@@ -249,6 +255,7 @@ fun SettingsScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
                 .background(MaterialTheme.colorScheme.background)
+                .verticalScroll(rememberScrollState())
         ) {
 
             Spacer(modifier = Modifier.height(10.dp))
@@ -267,7 +274,7 @@ fun SettingsScreen(
                 UCSettingsCard(
                     itemName = stringResource(R.string.change_theme),
                     itemSubText = stringResource(R.string.cycle_through_light_dark_system),
-                    onClick = { themeViewModel.toggleTheme() }
+                    onClick = { openThemeDialog = true }
                 )
             }
 
@@ -292,7 +299,7 @@ fun SettingsScreen(
 
                 HorizontalDivider(
                     thickness = 2.dp,
-                    color = SurfaceLight
+                    color = MaterialTheme.colorScheme.surface
                 )
 
                 UCSwitchCard(
@@ -306,7 +313,7 @@ fun SettingsScreen(
 
                 HorizontalDivider(
                     thickness = 2.dp,
-                    color = SurfaceLight
+                    color = MaterialTheme.colorScheme.surface
                 )
 
                 UCSwitchCard(
@@ -320,7 +327,7 @@ fun SettingsScreen(
 
                 HorizontalDivider(
                     thickness = 2.dp,
-                    color = SurfaceLight
+                    color = MaterialTheme.colorScheme.surface
                 )
 
                 UCSettingsCard(
@@ -335,7 +342,7 @@ fun SettingsScreen(
 
                 HorizontalDivider(
                     thickness = 2.dp,
-                    color = SurfaceLight
+                    color = MaterialTheme.colorScheme.surface
                 )
 
 
@@ -356,7 +363,7 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .padding(start = 16.dp, end = 18.dp, top = 18.dp),
                 text = stringResource(R.string.danger_zone),
-                style = medium18.copy(color = OnPrimaryContainerLight)
+                style = medium18.copy(color = MaterialTheme.colorScheme.onBackground)
             )
 
             Spacer(modifier = Modifier.height(14.dp))

--- a/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/settings/SettingsScreen.kt
@@ -52,13 +52,16 @@ import com.aritradas.uncrack.ui.theme.SurfaceLight
 import com.aritradas.uncrack.ui.theme.medium14
 import com.aritradas.uncrack.ui.theme.medium18
 import com.aritradas.uncrack.ui.theme.normal16
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.aritradas.uncrack.sharedViewModel.ThemeViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     navController: NavHostController,
     settingsViewModel: SettingsViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    themeViewModel: ThemeViewModel = hiltViewModel()
 ) {
 
     val context = LocalContext.current
@@ -245,15 +248,35 @@ fun SettingsScreen(
             modifier = modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
         ) {
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 18.dp, top = 18.dp),
+                text = stringResource(R.string.theme),
+                style = medium18.copy(color = MaterialTheme.colorScheme.onBackground)
+            )
+
+            Spacer(modifier = Modifier.height(14.dp))
+
+            SettingsItemGroup {
+                UCSettingsCard(
+                    itemName = stringResource(R.string.change_theme),
+                    itemSubText = stringResource(R.string.cycle_through_light_dark_system),
+                    onClick = { themeViewModel.toggleTheme() }
+                )
+            }
 
             Text(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 16.dp, end = 18.dp, top = 18.dp),
                 text = stringResource(id = R.string.security),
-                style = medium18.copy(color = OnPrimaryContainerLight)
+                style = medium18.copy(color = MaterialTheme.colorScheme.onBackground)
             )
 
             Spacer(modifier = Modifier.height(14.dp))

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
@@ -1,7 +1,6 @@
 package com.aritradas.uncrack.presentation.tools
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -32,8 +31,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.navigation.Screen
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.SurfaceVariantLight
 import com.aritradas.uncrack.ui.theme.medium18
 import com.aritradas.uncrack.ui.theme.normal14
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/ToolsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,7 +40,9 @@ import com.aritradas.uncrack.ui.theme.normal14
 @Composable
 fun ToolsScreen(
     navController: NavController,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    generatorIconId: Int = R.drawable.generate_password_new,
+    shieldIconId: Int = R.drawable.shield
 ) {
 
     val context = LocalContext.current
@@ -55,7 +59,7 @@ fun ToolsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(16.dp),
         ) {
 
@@ -66,7 +70,7 @@ fun ToolsScreen(
                     .clickable {
                         navController.navigate(Screen.GeneratorScreen.name)
                     }
-                    .background(SurfaceVariantLight)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
                     .shadow(
                         elevation = 5.dp,
                         spotColor = Color(0x0D666666),
@@ -76,9 +80,9 @@ fun ToolsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
 
-                Image(
+                Icon(
                     modifier = Modifier.size(30.dp),
-                    painter = painterResource(id = R.drawable.generate_password_new),
+                    painter = painterResource(id = generatorIconId),
                     contentDescription = null
                 )
 
@@ -90,13 +94,13 @@ fun ToolsScreen(
                 ) {
                     Text(
                         text = stringResource(id = R.string.generator),
-                        color = Color.Black,
+                        color = MaterialTheme.colorScheme.onSurface,
                         style = medium18
                     )
 
                     Text(
                         text = stringResource(R.string.quickly_generate_your_passwords_and_usernames),
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         style = normal14
                     )
                 }
@@ -111,7 +115,7 @@ fun ToolsScreen(
                     .clickable {
                         navController.navigate(Screen.PasswordHealthScreen.name)
                     }
-                    .background(SurfaceVariantLight)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
                     .shadow(
                         elevation = 5.dp,
                         spotColor = Color(0x0D666666),
@@ -120,9 +124,9 @@ fun ToolsScreen(
                     .padding(horizontal = 16.dp, vertical = 17.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Image(
+                Icon(
                     modifier = Modifier.size(30.dp),
-                    painter = painterResource(id = R.drawable.shield),
+                    painter = painterResource(id = shieldIconId),
                     contentDescription = null
                 )
 
@@ -134,13 +138,13 @@ fun ToolsScreen(
                 ) {
                     Text(
                         text = stringResource(R.string.password_health),
-                        color = Color.Black,
+                        color = MaterialTheme.colorScheme.onSurface,
                         style = medium18
                     )
 
                     Text(
                         text = stringResource(R.string.identify_passwords_health),
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         style = normal14
 
                     )

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
@@ -46,7 +47,7 @@ fun GeneratorScreen(
             UCTopAppBar(
                 modifier = Modifier.fillMaxWidth(),
                 title = stringResource(R.string.generator),
-                colors = TopAppBarDefaults.topAppBarColors(BackgroundLight),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
                 onBackPress = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/generator/GeneratorScreen.kt
@@ -27,7 +27,6 @@ import com.aritradas.uncrack.presentation.tools.usernameGenerator.UsernameGenera
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGenerator
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.PasswordGeneratorViewModel
 import com.aritradas.uncrack.presentation.tools.usernameGenerator.UsernameGeneratorViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -44,10 +44,6 @@ import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCButton
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.PrimaryLight
-import com.aritradas.uncrack.ui.theme.SurfaceLight
 import com.aritradas.uncrack.ui.theme.medium24
 import com.aritradas.uncrack.ui.theme.medium30
 import com.aritradas.uncrack.ui.theme.normal16
@@ -171,7 +167,7 @@ fun PasswordGenerator(
 
         Text(
             text = stringResource(R.string.include_following),
-            style = medium24.copy(OnPrimaryContainerLight)
+            style = medium24.copy(color = MaterialTheme.colorScheme.onSurface)
         )
 
         SwitchItem(
@@ -216,7 +212,7 @@ fun SwitchItem(
     ) {
         Text(
             text = label,
-            style = normal16.copy(OnPrimaryContainerLight)
+            style = normal16.copy(color = MaterialTheme.colorScheme.onSurface)
         )
 
         Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -97,7 +97,7 @@ fun PasswordGenerator(
             text = buildAnnotatedString {
                 password.forEach {
                     val textColor = when {
-                        it.isDigit() -> Color.Blue
+                        it.isDigit() -> Color.Cyan
                         it.isLetterOrDigit().not() -> Color.Magenta
                         else -> MaterialTheme.colorScheme.onPrimaryContainer
                     }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordGenerator/PasswordGenerator.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Switch
@@ -90,7 +91,7 @@ fun PasswordGenerator(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(BackgroundLight)
+            .background(MaterialTheme.colorScheme.background)
             .verticalScroll(scrollState)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -102,7 +103,7 @@ fun PasswordGenerator(
                     val textColor = when {
                         it.isDigit() -> Color.Blue
                         it.isLetterOrDigit().not() -> Color.Magenta
-                        else -> OnPrimaryContainerLight
+                        else -> MaterialTheme.colorScheme.onPrimaryContainer
                     }
                     withStyle(style = SpanStyle(color = textColor)) {
                         append(it.toString())
@@ -143,7 +144,7 @@ fun PasswordGenerator(
 
         Text(
             text = stringResource(R.string.password_generated_length, passwordLength.toInt()),
-            style = medium24.copy(OnPrimaryContainerLight)
+            style = medium24.copy(MaterialTheme.colorScheme.onPrimaryContainer)
         )
 
         Slider(
@@ -158,9 +159,9 @@ fun PasswordGenerator(
             steps = sliderSteps,
             valueRange = sliderStepRange,
             colors = SliderDefaults.colors(
-                thumbColor = OnPrimaryContainerLight,
-                activeTrackColor = PrimaryLight,
-                inactiveTrackColor = SurfaceLight,
+                thumbColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                activeTrackColor = MaterialTheme.colorScheme.primary,
+                inactiveTrackColor = MaterialTheme.colorScheme.surface,
                 activeTickColor = Color.Transparent,
                 inactiveTickColor = Color.Transparent
             )

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordHealth/PasswordHealthScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordHealth/PasswordHealthScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -46,7 +47,7 @@ fun PasswordHealthScreen(
             UCTopAppBar(
                 modifier = Modifier.fillMaxWidth(),
                 title = "Password Health",
-                colors = TopAppBarDefaults.topAppBarColors(BackgroundLight),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
                 onBackPress = { navController.popBackStack() }
             )
         }
@@ -56,7 +57,7 @@ fun PasswordHealthScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(16.dp)
         ) {
             ShieldCard(

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordHealth/PasswordHealthScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/passwordHealth/PasswordHealthScreen.kt
@@ -22,7 +22,6 @@ import androidx.navigation.NavController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.ShieldCard
 import com.aritradas.uncrack.components.UCTopAppBar
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.strongPassword
 import com.aritradas.uncrack.ui.theme.weakPassword
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
@@ -23,8 +23,6 @@ import androidx.compose.ui.unit.dp
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCButton
 import com.aritradas.uncrack.presentation.tools.passwordGenerator.SwitchItem
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.medium24
 import com.aritradas.uncrack.ui.theme.medium30
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/tools/usernameGenerator/UsernameGenerator.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -47,7 +48,7 @@ fun UsernameGenerator(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(BackgroundLight)
+            .background(MaterialTheme.colorScheme.background)
             .verticalScroll(scrollState)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -79,7 +80,7 @@ fun UsernameGenerator(
 
         Text(
             text = stringResource(R.string.include_following),
-            style = medium24.copy(OnPrimaryContainerLight)
+            style = medium24.copy(MaterialTheme.colorScheme.onPrimaryContainer)
         )
 
         SwitchItem(

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/AccountSelectionScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/AccountSelectionScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -72,9 +73,9 @@ fun AccountSelectionScreen(
                 },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = BackgroundLight,
-                    scrolledContainerColor = BackgroundLight,
-                    titleContentColor = Color.Black
+                    containerColor = MaterialTheme.colorScheme.background,
+                    scrolledContainerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground
                 )
             )
         }
@@ -83,14 +84,14 @@ fun AccountSelectionScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             item {
                 Text(
                     text = stringResource(id = R.string.social),
-                    style = medium20.copy(Color.Black)
+                    style = medium20.copy(MaterialTheme.colorScheme.onBackground)
                 )
                 Spacer(modifier = Modifier.height(10.dp))
             }
@@ -115,7 +116,7 @@ fun AccountSelectionScreen(
 
                 Text(
                     text = stringResource(id = R.string.work),
-                    style = medium20.copy(Color.Black)
+                    style = medium20.copy(MaterialTheme.colorScheme.onBackground)
                 )
                 Spacer(modifier = Modifier.height(10.dp))
             }
@@ -140,7 +141,7 @@ fun AccountSelectionScreen(
 
                 Text(
                     text = stringResource(R.string.crowdsourcing),
-                    style = medium20.copy(Color.Black)
+                    style = medium20.copy(MaterialTheme.colorScheme.onBackground)
                 )
 
                 Spacer(modifier = Modifier.height(10.dp))
@@ -167,7 +168,7 @@ fun AccountSelectionScreen(
 
                 Text(
                     text = stringResource(R.string.communication),
-                    style = medium20.copy(Color.Black)
+                    style = medium20.copy(MaterialTheme.colorScheme.onBackground)
                 )
 
                 Spacer(modifier = Modifier.height(10.dp))
@@ -194,7 +195,7 @@ fun AccountSelectionScreen(
 
                 Text(
                     text = stringResource(R.string.portfolio),
-                    style = medium20.copy(Color.Black)
+                    style = medium20.copy(MaterialTheme.colorScheme.onBackground)
                 )
                 Spacer(modifier = Modifier.height(10.dp))
             }
@@ -221,7 +222,7 @@ fun AccountSelectionScreen(
 
                 Text(
                     text = stringResource(R.string.communities),
-                    style = medium20.copy(Color.Black)
+                    style = medium20.copy(MaterialTheme.colorScheme.onBackground)
                 )
                 Spacer(modifier = Modifier.height(10.dp))
             }

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/AccountSelectionScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/AccountSelectionScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -30,7 +29,6 @@ import androidx.navigation.NavHostController
 import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.AccountCard
 import com.aritradas.uncrack.presentation.vault.viewmodel.AddEditViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.medium20
 import com.aritradas.uncrack.util.UtilsKt.getCommunicationAccounts
 import com.aritradas.uncrack.util.UtilsKt.getCommunitiesAccounts

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/AddPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/AddPasswordScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -92,7 +93,7 @@ fun AddPasswordScreen(
             .imePadding(),
         topBar = {
             MediumTopAppBar(
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = BackgroundLight),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
                 title = {
                     Text(
                         "Add Password",
@@ -116,7 +117,7 @@ fun AddPasswordScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(16.dp)
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -131,7 +132,7 @@ fun AddPasswordScreen(
 
             Text(
                 text = accountName,
-                style = medium22.copy(Color.Black)
+                style = medium22.copy(MaterialTheme.colorScheme.onBackground)
             )
 
             Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/AddPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/AddPasswordScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -56,7 +55,6 @@ import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.domain.model.Account
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.vault.viewmodel.AddEditViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.medium22
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/EditPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/EditPasswordScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -88,7 +89,7 @@ fun EditPasswordScreen(
             UCTopAppBar(
                 modifier = Modifier.fillMaxWidth(),
                 title = "Edit Password",
-                colors = TopAppBarDefaults.topAppBarColors(BackgroundLight),
+                colors = TopAppBarDefaults.topAppBarColors(MaterialTheme.colorScheme.background),
                 onBackPress = { navController.popBackStack() }
             )
         }
@@ -97,7 +98,7 @@ fun EditPasswordScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(paddingValues)
                 .padding(16.dp)
                 .verticalScroll(rememberScrollState()),
@@ -114,7 +115,7 @@ fun EditPasswordScreen(
 
             Text(
                 text = accountName.toString(),
-                style =  medium22.copy(Color.Black)
+                style = medium22.copy(MaterialTheme.colorScheme.onBackground)
             )
 
             Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/EditPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/EditPasswordScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -48,7 +47,6 @@ import com.aritradas.uncrack.components.UCTopAppBar
 import com.aritradas.uncrack.domain.model.Account
 import com.aritradas.uncrack.navigation.Screen
 import com.aritradas.uncrack.presentation.vault.viewmodel.ViewPasswordViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
 import com.aritradas.uncrack.ui.theme.medium22
 import com.aritradas.uncrack.util.UtilsKt.generateRandomPassword
 import com.aritradas.uncrack.util.UtilsKt.getAccountImage

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/VaultScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/VaultScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
@@ -107,14 +108,14 @@ fun VaultScreen(
         topBar = {
             TopAppBar(
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = BackgroundLight,
+                    containerColor = MaterialTheme.colorScheme.background,
                 ),
                 title = {
                     Text(
                         modifier = Modifier
                             .fillMaxWidth(),
                         text = "Hello, ${user.name}",
-                        style = medium24.copy(Color.Black)
+                        style = medium24.copy(MaterialTheme.colorScheme.onBackground)
                     )
                 }
             )
@@ -135,7 +136,7 @@ fun VaultScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(horizontal = 16.dp)
                 .then(modifier),
         ) {
@@ -155,7 +156,7 @@ fun VaultScreen(
                     Row {
                         Text(
                             text = "Search for ",
-                            style = normal16.copy(OnSurfaceVariantLight),
+                            style = normal16.copy(MaterialTheme.colorScheme.onSurfaceVariant),
                         )
                         TypewriterText(
                             texts = listOf(
@@ -168,7 +169,7 @@ fun VaultScreen(
                     }
                 },
                 colors = SearchBarDefaults.colors(
-                    containerColor = PrimaryContainerLight
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
                 ),
                 leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
                 trailingIcon = {

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/VaultScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/VaultScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -51,9 +50,6 @@ import com.aritradas.uncrack.components.TypewriterText
 import com.aritradas.uncrack.components.VaultCard
 import com.aritradas.uncrack.presentation.vault.viewmodel.VaultViewModel
 import com.aritradas.uncrack.sharedViewModel.UserViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.OnSurfaceVariantLight
-import com.aritradas.uncrack.ui.theme.PrimaryContainerLight
 import com.aritradas.uncrack.ui.theme.medium24
 import com.aritradas.uncrack.ui.theme.normal16
 

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/ViewPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/ViewPasswordScreen.kt
@@ -55,11 +55,6 @@ import com.aritradas.uncrack.R
 import com.aritradas.uncrack.components.UCTextField
 import com.aritradas.uncrack.components.UCTopAppBar
 import com.aritradas.uncrack.presentation.vault.viewmodel.ViewPasswordViewModel
-import com.aritradas.uncrack.ui.theme.BackgroundLight
-import com.aritradas.uncrack.ui.theme.OnPrimaryContainerLight
-import com.aritradas.uncrack.ui.theme.OnSurfaceVariantLight
-import com.aritradas.uncrack.ui.theme.SurfaceLight
-import com.aritradas.uncrack.ui.theme.SurfaceTintLight
 import com.aritradas.uncrack.ui.theme.medium14
 import com.aritradas.uncrack.ui.theme.medium22
 import com.aritradas.uncrack.ui.theme.normal12
@@ -122,13 +117,13 @@ fun ViewPasswordScreen(
                 title = {
                     Text(
                         text = stringResource(R.string.delete_account),
-                        style = normal16.copy(color = OnPrimaryContainerLight)
+                        style = normal16.copy(color = MaterialTheme.colorScheme.onPrimaryContainer)
                     )
                 },
                 text = {
                     Text(
                         text = stringResource(R.string.are_you_sure_you_want_to_delete),
-                        style = normal16.copy(color = OnSurfaceVariantLight)
+                        style = normal16.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
                     )
                 },
                 confirmButton = {
@@ -180,7 +175,7 @@ fun ViewPasswordScreen(
                 onBackPress = { navController.popBackStack() },
                 shouldShowFavAndEditButton = false,
                 onEditPress = { navigateToEditPasswordScreen(accountId) },
-                colors = TopAppBarDefaults.topAppBarColors(BackgroundLight),
+                colors = TopAppBarDefaults.topAppBarColors(MaterialTheme.colorScheme.background),
                 onDeletePress = { showDeleteDialog = true }
             )
         }
@@ -188,7 +183,7 @@ fun ViewPasswordScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(BackgroundLight)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(paddingValues)
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -204,7 +199,7 @@ fun ViewPasswordScreen(
 
             Text(
                 text = accountCompany.toString(),
-                style = medium22.copy(Color.Black)
+                style = medium22.copy(MaterialTheme.colorScheme.onBackground)
             )
 
             Spacer(modifier = Modifier.height(30.dp))
@@ -217,7 +212,7 @@ fun ViewPasswordScreen(
                         elevation = 10.dp,
                         shape = RoundedCornerShape(10.dp)
                     )
-                    .background(SurfaceLight),
+                    .background(MaterialTheme.colorScheme.surface),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
@@ -235,14 +230,14 @@ fun ViewPasswordScreen(
 
                     Text(
                         text = category.toString(),
-                        style = normal12.copy(OnSurfaceVariantLight)
+                        style = normal12.copy(MaterialTheme.colorScheme.onSurfaceVariant)
                     )
                 }
 
                 VerticalDivider(
                     modifier = Modifier.height(40.dp),
                     thickness = 1.dp,
-                    color = SurfaceTintLight.copy(alpha = .5f)
+                    color = MaterialTheme.colorScheme.surfaceTint.copy(alpha = .5f)
                 )
 
                 Column(
@@ -262,28 +257,28 @@ fun ViewPasswordScreen(
                                 else -> strongPassword
                             },
                             strokeWidth = 5.dp,
-                            trackColor = SurfaceTintLight,
+                            trackColor = MaterialTheme.colorScheme.surfaceTint,
                             strokeCap = StrokeCap.Round,
                         )
 
                         Text(
                             text = progressMessage,
                             style = normal12,
-                            color = OnPrimaryContainerLight,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
                         )
 
                     }
 
                     Text(
                         text = stringResource(R.string.password_strength),
-                        style = normal12.copy(OnSurfaceVariantLight)
+                        style = normal12.copy(MaterialTheme.colorScheme.onSurfaceVariant)
                     )
                 }
 
                 VerticalDivider(
                     modifier = Modifier.height(40.dp),
                     thickness = 1.dp,
-                    color = SurfaceTintLight.copy(alpha = .5f)
+                    color = MaterialTheme.colorScheme.surfaceTint.copy(alpha = .5f)
                 )
 
                 Column(
@@ -319,7 +314,7 @@ fun ViewPasswordScreen(
 
                     Text(
                         text = stringResource(R.string.share),
-                        style = normal12.copy(OnSurfaceVariantLight)
+                        style = normal12.copy(MaterialTheme.colorScheme.onSurfaceVariant)
                     )
 
                 }
@@ -371,7 +366,7 @@ fun ViewPasswordScreen(
                         else painterResource(id = R.drawable.visibility_on)
 
                         IconButton(onClick =
-                        { passwordVisibility = passwordVisibility.not() }
+                            { passwordVisibility = passwordVisibility.not() }
                         ) {
                             Icon(
                                 modifier = Modifier.size(24.dp),

--- a/app/src/main/java/com/aritradas/uncrack/presentation/vault/ViewPasswordScreen.kt
+++ b/app/src/main/java/com/aritradas/uncrack/presentation/vault/ViewPasswordScreen.kt
@@ -222,10 +222,10 @@ fun ViewPasswordScreen(
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Image(
+                    Icon(
                         modifier = Modifier.size(40.dp),
                         painter = getCategoryImage(category.toString()),
-                        contentDescription = null
+                        contentDescription = null,
                     )
 
                     Text(
@@ -287,7 +287,7 @@ fun ViewPasswordScreen(
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Image(
+                    Icon(
                         modifier = Modifier
                             .size(40.dp)
                             .clickable {

--- a/app/src/main/java/com/aritradas/uncrack/sharedViewModel/ThemeViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/sharedViewModel/ThemeViewModel.kt
@@ -4,8 +4,8 @@ import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.aritradas.uncrack.data.datastore.DataStoreUtil
-import com.aritradas.uncrack.data.datastore.DataStoreUtil.Companion.IS_DARK_MODE_KEY
 import com.aritradas.uncrack.data.datastore.DataStoreUtil.Companion.IS_SS_BLOCK_KEY
+import com.aritradas.uncrack.data.datastore.DataStoreUtil.Companion.THEME_MODE_KEY
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,14 +14,16 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-data class ThemeState(val isDarkMode: Boolean, val isSsBlocked: Boolean)
+data class ThemeState(val themeMode: ThemeMode, val isSsBlocked: Boolean)
+enum class ThemeMode { LIGHT, DARK, SYSTEM }
 
 @HiltViewModel
 class ThemeViewModel @Inject constructor(
     dataStoreUtil: DataStoreUtil
 ): ViewModel() {
 
-    private val _themeState = MutableStateFlow(ThemeState(isDarkMode = false, isSsBlocked = false))
+    private val _themeState =
+        MutableStateFlow(ThemeState(themeMode = ThemeMode.SYSTEM, isSsBlocked = false))
     val themeState: StateFlow<ThemeState> = _themeState
 
     private val dataStore = dataStoreUtil.dataStore
@@ -30,7 +32,9 @@ class ThemeViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             dataStore.data.map { preferences ->
                 ThemeState(
-                    isDarkMode = preferences[IS_DARK_MODE_KEY] ?: false,
+                    themeMode = ThemeMode.valueOf(
+                        preferences[THEME_MODE_KEY] ?: ThemeMode.SYSTEM.name
+                    ),
                     isSsBlocked = preferences[IS_SS_BLOCK_KEY] ?: false
                 )
             }.collect {
@@ -40,9 +44,14 @@ class ThemeViewModel @Inject constructor(
     }
 
     fun toggleTheme() {
+        val nextMode = when (_themeState.value.themeMode) {
+            ThemeMode.LIGHT -> ThemeMode.DARK
+            ThemeMode.DARK -> ThemeMode.SYSTEM
+            ThemeMode.SYSTEM -> ThemeMode.LIGHT
+        }
         viewModelScope.launch(Dispatchers.IO) {
             dataStore.edit { preferences ->
-                preferences[IS_DARK_MODE_KEY] = !(preferences[IS_DARK_MODE_KEY] ?: false)
+                preferences[THEME_MODE_KEY] = nextMode.name
             }
         }
     }

--- a/app/src/main/java/com/aritradas/uncrack/sharedViewModel/ThemeViewModel.kt
+++ b/app/src/main/java/com/aritradas/uncrack/sharedViewModel/ThemeViewModel.kt
@@ -43,15 +43,10 @@ class ThemeViewModel @Inject constructor(
         }
     }
 
-    fun toggleTheme() {
-        val nextMode = when (_themeState.value.themeMode) {
-            ThemeMode.LIGHT -> ThemeMode.DARK
-            ThemeMode.DARK -> ThemeMode.SYSTEM
-            ThemeMode.SYSTEM -> ThemeMode.LIGHT
-        }
+    fun setThemeMode(mode: ThemeMode) {
         viewModelScope.launch(Dispatchers.IO) {
             dataStore.edit { preferences ->
-                preferences[THEME_MODE_KEY] = nextMode.name
+                preferences[THEME_MODE_KEY] = mode.name
             }
         }
     }

--- a/app/src/main/java/com/aritradas/uncrack/ui/theme/Theme.kt
+++ b/app/src/main/java/com/aritradas/uncrack/ui/theme/Theme.kt
@@ -18,7 +18,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.aritradas.uncrack.sharedViewModel.ThemeMode
 import com.aritradas.uncrack.sharedViewModel.ThemeViewModel
+import androidx.compose.foundation.isSystemInDarkTheme
 
 private val DarkColorPalette = darkColorScheme(
     primary = PrimaryDark,
@@ -51,17 +53,22 @@ fun UnCrackTheme(
 ) {
     val themeState by themeViewModel.themeState.collectAsState()
 
+    val isDark = when (themeState.themeMode) {
+        ThemeMode.DARK -> true
+        ThemeMode.LIGHT -> false
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+    }
+
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
-            if (themeState.isDarkMode) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-
+            if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-        themeState.isDarkMode -> DarkColorPalette
+        isDark -> DarkColorPalette
         else -> LightColorPalette
     }
-    val view = LocalView.current
 
+    val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window

--- a/app/src/main/java/com/aritradas/uncrack/ui/theme/Theme.kt
+++ b/app/src/main/java/com/aritradas/uncrack/ui/theme/Theme.kt
@@ -72,11 +72,11 @@ fun UnCrackTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor =  colorScheme.background.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
+            window.statusBarColor = colorScheme.background.toArgb()
+            val isLight = !isDark
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = isLight
         }
     }
-
     MaterialTheme(
         colorScheme = colorScheme,
         typography = typography,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,7 @@
     <string name="log_out">Log Out</string>
     <string name="theme">Theme</string>
     <string name="change_theme">Change Theme</string>
-    <string name="cycle_through_light_dark_system">Switch between Light, Dark, and System theme modes</string>
+    <string name="cycle_through_light_dark_system">Switch between Dark, Light, and System theme modes</string>
     <string name="old_master_password">Old Master Password\n</string>
     <string name="new_master_password">New Master Password</string>
     <string name="at_least_1_symbol"><![CDATA[At least 1 symbol (*#/&%....)]]></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,8 @@
     <string name="delete_account">Delete account</string>
     <string name="log_out">Log Out</string>
     <string name="theme">Theme</string>
+    <string name="change_theme">Change Theme</string>
+    <string name="cycle_through_light_dark_system">Cycle through Light, Dark, and System themes</string>
     <string name="old_master_password">Old Master Password\n</string>
     <string name="new_master_password">New Master Password</string>
     <string name="at_least_1_symbol"><![CDATA[At least 1 symbol (*#/&%....)]]></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,7 @@
     <string name="log_out">Log Out</string>
     <string name="theme">Theme</string>
     <string name="change_theme">Change Theme</string>
-    <string name="cycle_through_light_dark_system">Cycle through Light, Dark, and System themes</string>
+    <string name="cycle_through_light_dark_system">Switch between Light, Dark, and System theme modes</string>
     <string name="old_master_password">Old Master Password\n</string>
     <string name="new_master_password">New Master Password</string>
     <string name="at_least_1_symbol"><![CDATA[At least 1 symbol (*#/&%....)]]></string>


### PR DESCRIPTION
Closes #258 

This pull request updates multiple UI components to support dynamic theming based on the user's light, dark, or system theme preference. It replaces hardcoded colors and custom theme references with MaterialTheme.colorScheme attributes, improving consistency, maintainability, and alignment with Material Design 3.

### Key Changes:

- Replaced hardcoded color values and custom theme variables (e.g. SurfaceVariantLight) with dynamic values from MaterialTheme.colorScheme.

- Updated components like AccountCard, PasswordCard, and dialogs to use consistent text and background colors based on the current theme mode.

- Ensured surfaces, dialogs, and text elements adapt automatically to the user's selected theme (light, dark, or system default).

These updates centralize color definitions, making future theme adjustments easier and ensuring a coherent look across all modes.

https://github.com/user-attachments/assets/882b0a36-ad58-4d7f-9f63-7413efe6a79a





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for switching between Dark, Light, and System theme modes, including a new theme selection dialog in Settings.
  - Updated theme management to use a tri-state system (Light, Dark, System) for more flexible appearance options.

- **Enhancements**
  - All screens and UI components now consistently use dynamic Material Design 3 color theming for backgrounds, text, and UI elements.
  - Improved theme-related strings and descriptions for better clarity.

- **Bug Fixes**
  - Ensured consistent appearance across the app when changing themes, eliminating issues with hardcoded or inconsistent colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->